### PR TITLE
Fixed tiny syntax issue

### DIFF
--- a/content/collections/extending-docs/publish-forms.md
+++ b/content/collections/extending-docs/publish-forms.md
@@ -56,7 +56,7 @@ public function edit(Product $product)
         'blueprint' => $blueprint->toPublishArray(),
         'values'    => $fields->values(),
         'meta'      => $fields->meta(),
-    ])
+    ]);
 }
 ```
 


### PR DESCRIPTION
In the publish forms documentation, there was a missing semi colon on the return. Just fixed it for you 👍 