### PR TITLE
Fix link to the application repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ In order to ensure that the Statamic community is welcoming to all and generally
 [docs]: https://statamic.dev/
 [discord]: https://statamic.com/discord
 [contribution]: https://github.com/statamic/cms/blob/master/CONTRIBUTING.md
-[app-repo]: https://github.com/statamicstatamic
+[app-repo]: https://github.com/statamic/statamic


### PR DESCRIPTION
I've updated the link to the Statamic application repo as it was linking to `statamicstatamic` instead of `statamic/statamic`.

This issue also needs to be fixed on the main `statamic/cms` repo too.