### PR TITLE
remove scroll bars from side navigation when not needed

### DIFF
--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -16,7 +16,7 @@
 {{ partial:partials/nav }}
 
 <div class="w-full max-w-screen-xl mx-auto pt-12 lg:flex relative" id="top">
-    <div id="side-nav" class="hidden lg:block w-full lg:w-1/4 xl:w-1/5 px-6 pt-1 pb-12 overflow-scroll min-h-screen">
+    <div id="side-nav" class="hidden lg:block w-full lg:w-1/4 xl:w-1/5 px-6 pt-1 pb-12 overflow-auto min-h-screen">
         {{ partial:side-nav }}
     </div>
     <div id="content" class="w-full lg:w-2/4 xl:w-3/5 px-4 lg:px-6 xl:px-12">


### PR DESCRIPTION
Currently the scroll bars for the navigation are always shown even if there is nothing to scroll (might only be visible on windows)

![image](https://user-images.githubusercontent.com/2805213/69433094-403a1000-0d3b-11ea-81d6-5f390320a8bb.png)
![image](https://user-images.githubusercontent.com/2805213/69433255-914a0400-0d3b-11ea-9aca-567f561e8e44.png)


With this change the scroll bars only appear when there is content to scroll.

