### PR TITLE
Small change to first install step

### DIFF
--- a/content/collections/docs/installation.md
+++ b/content/collections/docs/installation.md
@@ -17,7 +17,7 @@ composer create-project statamic/statamic my-site --prefer-dist --stability=dev
 
 ## Installing into existing Laravel apps
 
-1. Add the `statamic:install` command to `post-autoload-dump`.
+1. Add the `statamic:install` command to `post-autoload-dump` in `composer.json`.
 
     ``` json
     "post-autoload-dump": [

--- a/content/collections/docs/installation.md
+++ b/content/collections/docs/installation.md
@@ -24,7 +24,7 @@ composer create-project statamic/statamic my-site --prefer-dist --stability=dev
         "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
         "@php artisan package:discover --ansi",
         "@php artisan statamic:install --ansi"
-    ]
+    ],
     ```
 
 2. Require `statamic/cms`.


### PR DESCRIPTION
The default `composer.json` from laravel has a trailing comma in this snippet:

```
        "post-autoload-dump": [
            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
            "@php artisan package:discover --ansi"
        ],
```

This change saves a small gotcha for copy/pasters.