### PR TITLE
Use slug as arg in Utility::make function

### DIFF
--- a/content/collections/extending-docs/utilities.md
+++ b/content/collections/extending-docs/utilities.md
@@ -28,7 +28,7 @@ use Statamic\Facades\Utility;
 
 public function boot()
 {
-    Utility::make('french fries')
+    Utility::make('french-fries')
         ->view('fries-utility')
         ->register();
 }


### PR DESCRIPTION
The string `french fries` causes `UtilitiesController` to blow up, as its expecting a valid URL entity when it calls the `request->segment` method.