### PR TITLE
Remove semicolon from inside array

### DIFF
--- a/content/collections/extending-docs/permissions.md
+++ b/content/collections/extending-docs/permissions.md
@@ -56,7 +56,7 @@ Permission::register('view blog entries', function ($permission) {
         Permission::make('edit blog entries')->children([
             Permission::make('create blog entries'),
             Permission::make('delete blog entries')
-        ]);
+        ])
     ]);
 });
 ```


### PR DESCRIPTION
My code didn't work when I had the semi-colon here because it's inside an array.