### PR TITLE
Fixed text-input usage

### DIFF
--- a/content/collections/extending-docs/fieldtypes.md
+++ b/content/collections/extending-docs/fieldtypes.md
@@ -69,7 +69,8 @@ Statamic.$components.register('toggle_password-fieldtype', Fieldtype);
 <template>
     <div>
         <text-input :type="inputType" :value="value" @input="update">
-        <label><input type="checkbox" v-model="show" /> Show Password</label>
+            <label><input type="checkbox" v-model="show" /> Show Password</label>
+        </text-input>
     </div>
 </template>
 

--- a/content/collections/extending-docs/fieldtypes.md
+++ b/content/collections/extending-docs/fieldtypes.md
@@ -68,9 +68,8 @@ Statamic.$components.register('toggle_password-fieldtype', Fieldtype);
 ``` vue
 <template>
     <div>
-        <text-input :type="inputType" :value="value" @input="update">
-            <label><input type="checkbox" v-model="show" /> Show Password</label>
-        </text-input>
+        <text-input :type="inputType" :value="value" @input="update" />
+        <label><input type="checkbox" v-model="show" /> Show Password</label>
     </div>
 </template>
 


### PR DESCRIPTION
I've fixed the usage of the `text-input` component by adding an end tag to the documentation because you can't have a starting tag without an ending tag (most of the time anyway)