### PR TITLE
Typo "pagse" on static-caching.md intro

### DIFF
--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -3,7 +3,7 @@ title: 'Static Caching'
 template: page
 blueprint: page
 intro: |
-    There is nothing faster on the web than static pages. They're like the speed of light — the theoretical maximum speed of anything. Instead of rendering pagse dynamically, Statamic can cache static pages and pass routing to Apache or Nginx through reverse proxying.
+    There is nothing faster on the web than static pages. They're like the speed of light — the theoretical maximum speed of anything. Instead of rendering pages dynamically, Statamic can cache static pages and pass routing to Apache or Nginx through reverse proxying.
 stage: 3
 id: ffa24da8-3fee-4fc9-a81b-fcae8917bd74
 ---


### PR DESCRIPTION
There's a typo as part of the intro text on this page: https://statamic.dev/static-caching

![image](https://user-images.githubusercontent.com/3949335/70801186-23c34d80-1da6-11ea-8b3b-9d86d2492caa.png)

This PR fixes the typo. From "pagse" to "pages"
