### PR TITLE
Fix broken link to TipTap site

### DIFF
--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -126,7 +126,7 @@ partials/
 
 ## Extending Bard
 
-Bard uses [TipTap](https://tiptap.scrumpy.com) (which in turn is built on top of [ProseMirror][prosemirror]) as the foundation for our quintessential block-based editor.
+Bard uses [TipTap](https://tiptap.scrumpy.io) (which in turn is built on top of [ProseMirror][prosemirror]) as the foundation for our quintessential block-based editor.
 
 - Link to [TipTap Extensions](https://tiptap.scrumpy.io/docs/api/extensions.html)
 - Explain how to bootstrap said extensions and buttons


### PR DESCRIPTION
The link to TipTap [on the bard docs](https://statamic.dev/fieldtypes/bard#extending-bard) had an incorrect URL.

I've changed it from `.com` to `.io`.