### PR TITLE
It's make:tag, not make:tags

### DIFF
--- a/content/collections/extending-docs/tags.md
+++ b/content/collections/extending-docs/tags.md
@@ -101,7 +101,7 @@ introduced the `wildcard` method to prevent some infinite looping situations you
 You can generate a Tags class with a console command:
 
 ``` bash
-php please make:tags Foo
+php please make:tag Foo
 ```
 
 This'll create a class in `app/Tags` which will be automatically registered.


### PR DESCRIPTION
I tried to run make:tags but the command doesn't actually exist, where as make:tag does.

(sorry for the 2nd pr to the same doc within 2 minutes 😂)