### PR TITLE
Fix paths to resources & routes

### DIFF
--- a/content/collections/extending-docs/addons.md
+++ b/content/collections/extending-docs/addons.md
@@ -197,11 +197,11 @@ In your service provider, you may register any number of stylesheets or scripts 
 
 ``` php
 protected $scripts = [
-    __DIR__.'/resources/js/example.js'
+    __DIR__.'/../resources/js/example.js'
 ];
 
 protected $stylesheets = [
-    __DIR__.'/resources/css/example.css'
+    __DIR__.'/../resources/css/example.css'
 ];
 ```
 
@@ -227,7 +227,7 @@ You may also mark generic assets for publishing by providing a `publishables` ar
 
 ``` php
 protected $publishables = [
-    ___DIR__.'/resources/images' => 'images',
+    __DIR__.'/../resources/images' => 'images',
 ];
 ```
 
@@ -239,9 +239,9 @@ You may register three types of routes in your service provider.
 
 ``` php
 protected $routes = [
-    'cp' => __DIR__.'/routes/cp.php',
-    'actions' => __DIR__.'/routes/actions.php',
-    'web' => __DIR__.'/routes/web.php',
+    'cp' => __DIR__.'/../routes/cp.php',
+    'actions' => __DIR__.'/../routes/actions.php',
+    'web' => __DIR__.'/../routes/web.php',
 ];
 ```
 


### PR DESCRIPTION
Since an addon's ServiceProvider is in the `src` directory, paths to `resources` & `routes` should go up one level.
