### PR TITLE
Update class used to register custom user drivers

### DIFF
--- a/content/collections/knowledge-base/storing-users-somewhere-custom.md
+++ b/content/collections/knowledge-base/storing-users-somewhere-custom.md
@@ -8,7 +8,7 @@ you're free to write your own.
 
 You will need to write implementations for all the contracts located in `Statamic\Contracts\Auth`. Of course, you may extend the native classes and override where appropriate, instead of writing everything from scratch.
 
-In a service provider, use the `Statamic\Auth\UserRepositoryManager::repository()` method to define a custom repository driver:
+In a service provider, use the `Statamic\Auth\UserRepositoryManager::extend()` method to define a custom repository driver:
 
 ``` php
 public function register()

--- a/content/collections/knowledge-base/storing-users-somewhere-custom.md
+++ b/content/collections/knowledge-base/storing-users-somewhere-custom.md
@@ -8,12 +8,16 @@ you're free to write your own.
 
 You will need to write implementations for all the contracts located in `Statamic\Contracts\Auth`. Of course, you may extend the native classes and override where appropriate, instead of writing everything from scratch.
 
-In a service provider, use the `Statamic\Facades\User::repository()` method to define a custom repository driver:
+In a service provider, use the `Statamic\Auth\UserRepositoryManager::repository()` method to define a custom repository driver:
 
 ``` php
-Statamic\Facades\User::repository('custom', function ($app, $config) {
-    return new CustomUserRepository;
-});
+public function register()
+{
+    $this->app->get(\Statamic\Auth\UserRepositoryManager::class)
+        ->extend('custom', function ($app, $config) {
+            return new CustomUserRepository;
+        });
+}
 ```
 
 After you've registered the driver using the `repository` method, you'll want to create a repository in `config/statamic/users.php` that uses the new driver:


### PR DESCRIPTION
If I'm not mistaken, these parts of the docs are outdated and incorrect. The `Statamic\Facades\User` class returns an instance of the existing User repository in the container, not the manager needed to register a new driver as you'd anticipate. Additionally. calling the `repository` method on the manager as previously suggested doesn't actually do what you'd expect and add the implementation for the config to pick up later on - you instead need to call the `extend` method.

I'm not 100% certain about this, but from testing and looking around, the change I made in this pull request seems to be correct.

Additionally, this change shows the example code is in the `register` function so people know to put it there instead of `boot` in the service provider.