### PR TITLE
Add underscore and antlers filetype

### DIFF
--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -127,11 +127,11 @@ An alternative approach (for those who like DRY or small templates) is to create
 ```language-files
 partials/
 |-- sets/
-|   |-- gallery.html
-|   |-- image.html
-|   |-- poll.html
-|   |-- text.html
-|   |-- video.html
+|   |-- _gallery.antlers.html
+|   |-- _image.antlers.html
+|   |-- _poll.antlers.html
+|   |-- _text.antlers.html
+|   |-- _video.antlers.html
 ```
 
 ## Extending Bard

--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -127,11 +127,11 @@ An alternative approach (for those who like DRY or small templates) is to create
 ```language-files
 partials/
 |-- sets/
-|   |-- _gallery.antlers.html
-|   |-- _image.antlers.html
-|   |-- _poll.antlers.html
-|   |-- _text.antlers.html
-|   |-- _video.antlers.html
+|   |-- gallery.antlers.html
+|   |-- image.antlers.html
+|   |-- poll.antlers.html
+|   |-- text.antlers.html
+|   |-- video.antlers.html
 ```
 
 ## Extending Bard


### PR DESCRIPTION
When you don't use the underscore and `.antlers.html` filetype then the partial contents don't get picked up.

I've updated the documentation to reflect this.