### PR TITLE
site_url now site:url

### DIFF
--- a/content/collections/variables/site_url.md
+++ b/content/collections/variables/site_url.md
@@ -6,7 +6,7 @@ types:
 The URL of the site. Aliased by `homepage`.
 
 ```
-{{ site_url }}
+{{ site:url }}
 ```
 
 ``` .language-output


### PR DESCRIPTION
This tripped me up today. I think this changed in [beta32](https://github.com/statamic/cms/releases/tag/v3.0.0-beta.32).

I've submitted this PR for `site:url`, but the docs should probably be reviewed for other changes. This may not even be a correct PR - you may have more substantial work to do around the `site` variables.