### PR TITLE
Update forms.md

### DIFF
--- a/content/collections/docs/forms.md
+++ b/content/collections/docs/forms.md
@@ -72,35 +72,37 @@ This example dynamically renders each input's HTML. You could alternatively writ
 
 ```
 {{ form:super_fans }}
-    // show any errors here
-    {{ if errors }}
-        <div class="bg-red-300 text-white p-2">
-            {{ errors }}
-                {{ value }}<br>
-            {{ /errors }}
-        </div>
-    {{ /if }}
 
-    // show a success message after submitting here
+    // First let's check if this is after a submission, and if so, was it successful.
+    // If it was, just show the success message. After all, we don't want them submitting again once they've gotten in touch!
     {{ if success }}
         <div class="bg-green-300 text-white p-2">
             {{ success }}
         </div>
+    {{ else }}
+        // If we weren't successful, show any errors. If a fresh page load, there's no errors, so do nothing.
+        {{ if errors }}
+            <div class="bg-red-300 text-white p-2">
+                {{ errors }}
+                    {{ value }}<br>
+                {{ /errors }}
+            </div>
+        {{ /if }}
+
+        // Loop through and render the form inputs
+        {{ fields }}
+            <div class="p-2">
+                <label>{{ display }}</label>
+                <div class="p-1">{{ field }}</div>
+                {{ if error }}
+                    <p class="text-gray-500">{{ error }}</p>
+                {{ /if }}
+            </div>
+        {{ /fields }}
+
+        // This is just a submit button.
+        <button type="submit">Submit</button>
     {{ /if }}
-
-    // Loop through and render the form inputs
-    {{ fields }}
-        <div class="p-2">
-            <label>{{ display }}</label>
-            <div class="p-1">{{ field }}</div>
-            {{ if error }}
-                <p class="text-gray-500">{{ error }}</p>
-            {{ /if }}
-        </div>
-    {{ /fields }}
-
-    // This is just a submit button.
-    <button type="submit">Submit</button>
 
 {{ /form:super_fans }}
 ```


### PR DESCRIPTION
This form example – much like school and life – will influence the way people build forms for the rest of their Statamic careers (or until a security team smacks their wrists).

As such, it makes sense to be responsible and show them an example of how to set up a form that doesn't re-render form fields after a successful submission (and in doing so will help stop people spamming their forms, which is totally not rad).

Basically, on page load, is this a successful submit? If so, show the success message and don't render anything else.

If not, were there any errors? If so, render them. Otherwise, render the form.

Also, this is entirely to brand standards and, as much as it pained me, uses that /if approach that makes me want to 🤮. Love you guys really.