### PR TITLE
Vendor Name is not part of public path 

### DIFF
--- a/content/collections/extending-docs/addons.md
+++ b/content/collections/extending-docs/addons.md
@@ -250,7 +250,7 @@ This may be useful if you need more control around groups of assets to be publis
 > During development of your addon, rather than constantly running `vendor:publish`, consider symlinking your directory:
 >
 > ``` bash
-> ln -s /path/to/addons/example/resources public/vendor/example/package
+> ln -s /path/to/addons/example/resources public/vendor/package
 > ```
 
 ## Routing


### PR DESCRIPTION
The public path for vendor assets in Statamic no longer contains the vendor's name, just the name of the package, at least this is how I seem to have it setup in my apps.