### PR TITLE
Add a basic example of outputting the nav

### DIFF
--- a/content/collections/tags/nav.md
+++ b/content/collections/tags/nav.md
@@ -140,7 +140,7 @@ variables:
 ---
 ### Basic Example
 
-Here is an example to output your nav on the front-end.
+Here is an example of how to output your nav on the front-end.
 
 ```
 {{ nav include_home="true" }}

--- a/content/collections/tags/nav.md
+++ b/content/collections/tags/nav.md
@@ -138,6 +138,28 @@ variables:
       Recursively output the entire contents
       of the `nav` tag pair.
 ---
+### Basic Example
+
+Here is an example to output your nav on the front-end.
+
+```
+{{ nav include_home="true" }}
+  {{ title }}
+{{ /nav }}
+```
+
+Here Statamic will just output the names of all your navigation items. Now that we've output the nav we probably want to sprinkle some markup between our items. We can do something like this:
+
+```
+<ul>
+  {{ nav include_home="true" }}
+    <li>
+      <a href="{{ url }}"{{ if is_current || is_parent }} class="on"{{ /if }}>{{ title }}</a>
+    </li>
+  {{ /nav }}
+</ul>
+```
+
 ## Recursion {#recursion}
 
 It's possible to use recursive tags for semi-automatically creating deeply-nested lists of links as your navigations. A sample set-up looks something like this:


### PR DESCRIPTION
As a newcomer to Statamic it took me some time to understand how to output a basic nav once I'd created a couple of pages—this was mostly due to `include_home="true"` being an opt-in pattern that's not immediately obvious until I read the parameters carefully. I think having a couple of basic examples (with this parameter included) will really help newcomers like me.