### PR TITLE
Update user:reset_password_form example

### DIFF
--- a/content/collections/tags/user-reset_password_form.md
+++ b/content/collections/tags/user-reset_password_form.md
@@ -55,6 +55,9 @@ submitting, where the `success` condition will kick in and they will be shown a 
             </div>
         {{ /if }}
 
+        <label>E-Mail</label>
+        <input type="email" name="email" />
+
         <label>Password</label>
         <input type="password" name="password" />
 


### PR DESCRIPTION
The Statamic\Auth\ResetsPasswords trait validates against an email field.
This should be reflected on the frontend tag example in the docs.