### PR TITLE
Add disclaimer for pro features to docs

### DIFF
--- a/content/collections/docs/git-integration.md
+++ b/content/collections/docs/git-integration.md
@@ -1,6 +1,7 @@
 ---
 title: 'Git Integration'
 intro: Statamic can automate your version control workflow with Git. It can automatically commit and push content as it's changed, schedule commits, or allow users to commit and push changes from the control panel without having to understand how git works.
+plan: pro
 stage: 5
 id: c095fb87-4c02-462c-9e6f-dfe0b6889248
 ---

--- a/content/collections/docs/revisions.md
+++ b/content/collections/docs/revisions.md
@@ -3,6 +3,7 @@ title: Revisions
 intro: The Revisions feature adds an entire publishing workflow to your authoring process. You can create revisions, schedule updates to your content, review and rollback to previous revisions of your content, and more.
 template: page
 id: 6177b316-0eed-4dec-83d1-e5a48a8e00b6
+plan: pro
 stage: 3
 ---
 

--- a/content/collections/docs/users.md
+++ b/content/collections/docs/users.md
@@ -6,6 +6,7 @@ updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
 updated_at: 1568645051
 id: 6b691e04-8f28-4eb2-8288-b61433883fe4
 blueprint: page
+plan: pro
 stage: 2
 ---
 ## Overview

--- a/resources/blueprints/page.yaml
+++ b/resources/blueprints/page.yaml
@@ -10,6 +10,23 @@ sections:
           type: markdown
           localizable: true
       -
+        handle: plan
+        field:
+          options:
+            free: null
+            mixed: null
+            pro: null
+          clearable: false
+          multiple: false
+          searchable: true
+          taggable: false
+          push_tags: false
+          cast_booleans: false
+          type: select
+          localizable: false
+          listable: hidden
+          display: Plan
+      -
         handle: content
         field:
           display: Content

--- a/resources/css/markdown.css
+++ b/resources/css/markdown.css
@@ -69,6 +69,17 @@
             z-index: 10;
         }
 
+        &.neat:before {
+            content: '';
+            background: url('/img/neat.svg') no-repeat;
+            height: 50px;
+            width: 64px;
+            position: absolute;
+            top: -10px;
+            left: -32px;
+            z-index: 10;
+        }
+
         p {
             @apply text-sm;
             &:last-child { @apply mb-0; }

--- a/resources/views/page.antlers.html
+++ b/resources/views/page.antlers.html
@@ -4,5 +4,15 @@
 </header>
 
 <article class="markdown pb-8">
+    {{ if plan == "pro" }}
+    <blockquote class="neat">
+        <p>This feature is part of the <a href="https://statamic.com/pricing">pro plan</a>.</p>
+    </blockquote>
+    {{ elseif plan == "mixed" }}
+    <blockquote class="neat">
+        <p>Some of these features are a part of the <a href="https://statamic.com/pricing">pro plan</a>.</p>
+    </blockquote>
+    {{ /if }}
+
     {{ content | noparse | toc:ids }}
 </article>


### PR DESCRIPTION
The docs currently leave out mention of Pro features. This left me for a loop and I had to message my brother about why Users was missing on my install. I went ahead and built out a version of this functionality - and played more with Statamic. Statamic is legit!

Also noticed said brother also fixed this in #169. This is an alternative and more wholistic approach to fix #145 

The neat.svg and class should probably be replaced with a pro version and the copy might need to be updated. Alternatively, rather than a pro/mixed/free, you might want to use a toggle to show the pro banner with custom text for each page. 
Free free to decline/edit/take inspiration and thanks for the awesome CMS with generous personal free tier 😍 