### PR TITLE
Fixed link to relationship fieldtypes

### DIFF
--- a/content/collections/docs/upgrade-guide.md
+++ b/content/collections/docs/upgrade-guide.md
@@ -217,7 +217,7 @@ Most of the global functions have been removed in an effort to prevent pollution
 
 ### Suggest Modes
 
-Suggest modes have been replaced by [customized relationship fieldtypes](/guide/extending/relationship-fieldtypes.html).
+Suggest modes have been replaced by [customized relationship fieldtypes](/extending/relationship-fieldtypes).
 
 ### Statamic\API
 


### PR DESCRIPTION
The link points to https://statamic.dev/guide/extending/relationship-fieldtypes.html instead of https://statamic.dev/extending/relationship-fieldtypes which results in a soft 404.