### PR TITLE
Fixed link to "Other Template Engines" page

### DIFF
--- a/content/collections/docs/views.md
+++ b/content/collections/docs/views.md
@@ -167,5 +167,5 @@ resources/views/
 
 - If you want to learn more about how data gets into your view, check out [The Cascade](/cascade)
 - If you'd like to manipulate your data _before_ it arrives in your view, check out [View Models](/view-models).
-- If you want to use a third-party template engine (like Twig), check out [Other Template Engines](/other-template-engines).
+- If you want to use a third-party template engine (like Twig), check out [Other Template Engines](/template-engines).
 - If you want to fetch data from Laravel or do other more programmery-things, you'll want to do that from a [Controller](/controllers).


### PR DESCRIPTION
The "Other Template Engines" link under Additional Reading points to https://statamic.dev/other-template-engines instead of https://statamic.dev/template-engines which results in a visit to Clippy on the 404 page. He was less lonely for a minute.