### PR TITLE
Added 'Exif PHP Extension' to server requirement

### DIFF
--- a/content/collections/docs/requirements.md
+++ b/content/collections/docs/requirements.md
@@ -15,6 +15,7 @@ To run Statamic 3 you'll need a server meeting the following requirements. These
 - PHP `>= 7.2.5`
 - BCMath PHP Extension
 - Ctype PHP Extension
+- Exif PHP Extension
 - JSON PHP Extension
 - Mbstring PHP Extension
 - OpenSSL PHP Extension


### PR DESCRIPTION
Without this extension I receive the following error when retrieving thumbnails etc
> Intervention\Image\Exception\NotSupportedException
> Reading Exif data is not supported by this PHP installation.