### PR TITLE
Update modifiers.md

### DIFF
--- a/content/collections/docs/modifiers.md
+++ b/content/collections/docs/modifiers.md
@@ -19,7 +19,7 @@ You could take some text, render it as markdown, uppercase it, and ensure there 
 
 ```
 // This...
-{{ "Ruth, Ruth, Ruth! Baby Ruth!" | markdown | uppercase | widont }}
+{{ "Ruth, Ruth, Ruth! Baby Ruth!" | markdown | upper | widont }}
 
 // Becomes this!
 <p>RUTH, RUTH, RUTH! BABY&nbsp;RUTH!</p>


### PR DESCRIPTION
This example broke for me while working through the docs. There is no modifier `uppercase` but there is `upper`. When changed locally my output matches the proposed output in the example.