### PR TITLE
Update this to be a little easier

### DIFF
--- a/content/collections/tags/user-profile.md
+++ b/content/collections/tags/user-profile.md
@@ -66,7 +66,7 @@ To output the currently logged in user's details, you can do this:
 
 ```
 {{ user }}
-  The current user's name is {{ first_name }} {{ last_name }}.
+  The current user's name is {{ name }}.
 {{ /user }}
 ```
 


### PR DESCRIPTION
Just had someone on the Discord with the default Statamic setup who tried to use the `{{ first_name }}` and `{{ last_name }}` variables in the user variable which obvisouly won't work as those fields aren't there by default.

In this PR, I've updated it to just be `{{ name }}`  