### PR TITLE
Document the new key param on the cache tag

### DIFF
--- a/content/collections/tags/cache.md
+++ b/content/collections/tags/cache.md
@@ -12,6 +12,10 @@ parameters:
     name: scope
     type: 'string'
     description: 'Sets the cache scope. The default `site` scope will cache one instance per tag for the entire site, while a `page` scope will create a unique cache per URL.'
+   -
+    name: key
+    type: 'string'
+    description: 'Sets the key used to store the value in the Laravel cache. `key` can't be used at the same time as `scope`.'
 stage: 4
 id: 1d0d2d1f-734b-4360-af7a-6792bf670bc7
 ---


### PR DESCRIPTION
This pull request adds the new `key` parameter to the documentation of the Cache tag.

This functionality was implemented in statamic/cms#2589.