### PR TITLE
Update form example for dashboard widget

### DIFF
--- a/content/collections/docs/widgets.md
+++ b/content/collections/docs/widgets.md
@@ -37,7 +37,7 @@ Display a listing of form submissions.
 
 ``` php
 [
-	'type' => 'collection',
+	'type' => 'form',
 	'form' => 'contact', // name of your form
 	'width' => 100,
 	'limit' => 10


### PR DESCRIPTION
The singular form example and the full example of possible widgets are inconsistent, and the singular form example, if attempted, will cause an error. Updated the form example to be inline with the full example.