### PR TITLE
Update formSubmitted event

### DIFF
--- a/content/collections/extending-docs/events.md
+++ b/content/collections/extending-docs/events.md
@@ -308,7 +308,7 @@ Dispatched when a [Form](/forms) is submitted on the front-end, before the Submi
 ``` php
 public function handle(FormSubmitted $event)
 {
-    $event->form; // The Submission object
+    $event->submission; // The Submission object
 }
 ```
 


### PR DESCRIPTION
This PR does respect the deprecated form attribute:

https://github.com/statamic/cms/blob/master/src/Events/FormSubmitted.php#L15