### PR TITLE
Add a note around pointing web server at public folder

### DIFF
--- a/content/collections/docs/installation.md
+++ b/content/collections/docs/installation.md
@@ -17,6 +17,8 @@ composer create-project --prefer-dist statamic/statamic {change_me}
 
 _(hint: replace `{change_me}` with whatever you'd like to name your site.)_
 
+After you've installed, make sure to point your web server to your `public` folder. If you use Laravel Valet, that will be automatically picked up.
+
 ### Starter Kits
 
 You can also use one of the starter kits to jump ahead with a pre-built site. Each starter kit has its own installation docs.


### PR DESCRIPTION
I've seen a few people struggle with getting Statamic setup locally and the issue was that they weren't pointing their web server at the `public` folder, instead they were pointing it at the root project folder.

Example: https://statamic.com/forum/4931-struggling-on-first-install

Hopefully adding a line like this will help to avoid any confusion.