### PR TITLE
Fix 'filter' parameter description

### DIFF
--- a/content/collections/tags/taxonomy.md
+++ b/content/collections/tags/taxonomy.md
@@ -39,7 +39,7 @@ parameters:
     description: >
       Filter the listing by either a custom
       class or using a special syntax, both of
-      which are outlined in more detail within the **Filtering** section on this page.
+      which are outlined in more detail within the [Filtering](#filtering) section.
 variables:
   -
     name: first

--- a/content/collections/tags/taxonomy.md
+++ b/content/collections/tags/taxonomy.md
@@ -39,7 +39,7 @@ parameters:
     description: >
       Filter the listing by either a custom
       class or using a special syntax, both of
-      which are outlined in more detail below.
+      which are outlined in more detail within the **Filtering** section on this page.
 variables:
   -
     name: first


### PR DESCRIPTION
It looks like you guys are automatically appending the "Parameters" and "Variables" sections to the end of this page, so the "Filtering" section doesn't end up being the last section on the page. This means that the "filter" parameter is incorrect where it says "outlined in more detail below"