### PR TITLE
Fix {{ get_content }} example

### DIFF
--- a/content/collections/tags/get_content.md
+++ b/content/collections/tags/get_content.md
@@ -49,7 +49,7 @@ related_by_id: 123-321-abc-defg123
   {{ title }}
 {{ /get_content:related_by_uri }}
 
-{{ get_content:related_by_entry }}
+{{ get_content:related_by_id }}
   {{ title }}
-{{ /get_content:related_by_entry }}
+{{ /get_content:related_by_id }}
 ```


### PR DESCRIPTION
The variable should be `related_by_id` as per the front matter in the example.