### PR TITLE
Remove --with-dependencies parameter from installation docs

### DIFF
--- a/content/collections/docs/installation.md
+++ b/content/collections/docs/installation.md
@@ -87,7 +87,7 @@ Statamic is updated using Composer either directly on the command line or throug
 From within your project, use Composer to update the Statamic CMS package:
 
 ``` bash
-composer update statamic/cms --with-dependencies
+composer update statamic/cms
 ```
 
 You may prefer to run `composer update` to update _all_ of your dependencies listed in your composer.json file


### PR DESCRIPTION
This pull request removes the `--with-dependencies` parameter from the update documentation. As it would throw errors if some people are running Laravel 7 sites. I'm sure this parameter was added for a reason...

See statamic/cms#2803.