### PR TITLE
Make it clear to add `antlers` suffix to replicator partials

### DIFF
--- a/content/collections/fieldtypes/replicator.md
+++ b/content/collections/fieldtypes/replicator.md
@@ -119,13 +119,13 @@ An alternative, and often cleaner, approach is to have multiple 'set' partials a
 ```
 Then inside your partials directory you could have:
 
-`sets/image.html`
-`sets/quote.html`
+`sets/image.antlers.html`
+`sets/quote.antlers.html`
 
 and the set partial may look something like:
 
 ```
-{{# this is image.html #}}
+{{# this is image.antlers.html #}}
 
 <img src="{{ image }}" alt="{{ caption }}" >
 ```


### PR DESCRIPTION
I'm new to statamic and had issues following along these docs because my variables weren't rendered properly when moving replicator sets into partials as suggested. I've found that it works as soon as I add the antlers suffix to my partials, so I guess it would be nice having this in the docs.