### PR TITLE
Update list of variables available in mail templates

### DIFF
--- a/content/collections/docs/forms.md
+++ b/content/collections/docs/forms.md
@@ -163,6 +163,8 @@ Inside your email view, you have a number of variables available:
 - `date`, `now`, `today` - The current date/time
 - `site_url` - The site home page.
 - `site`, `locale` - The handle of the site
+- `config` - Any configuration values
+- Any data from [Global Sets](/globals#global-sets)
 - All of the submitted form values
 - A `fields` array
 


### PR DESCRIPTION
This pull request adds config values and global set data to the list of variables that are available while in mail templates.

Config values were just recently merged, see statamic/cms#2847, so would likely be a good idea to merge this after v3.0.28 is tagged.