### PR TITLE
Document no taxonomy routes as a breaking change

### DIFF
--- a/content/collections/docs/upgrade-guide.md
+++ b/content/collections/docs/upgrade-guide.md
@@ -63,6 +63,7 @@ First, let's look at the breaking changes on the core application side. These ar
 - Removed `theme:partial` tag in favor of `partial`.
 - The `content` field is no longer automatically parsed for Antlers. You can flag it for parsing in the [blueprint](/blueprints). (As well as any other fields)
 - Inside loops `index` now starts at `0`, `count` starts at `1`, and `zero_index` is no more.
+- Statamic no longer automatically registers routes for taxonomies. If you need them, you can register them yourself.
 
 ### Collections
 


### PR DESCRIPTION
This pull request documents that taxonomy routes are no longer automatically registered in v3, like they were in v2. [This comment](https://github.com/statamic/cms/issues/2403#issuecomment-734319350) pointed it out it wasn't already documented as part of the breaking changes in the upgrade guide.

Have a nice thanksgiving!