### PR TITLE
Fieldtype updates to better reflect Blueprint create options

### DIFF
--- a/content/collections/fieldtypes/form.md
+++ b/content/collections/fieldtypes/form.md
@@ -1,0 +1,17 @@
+---
+title: Form
+intro: 'A form picker to relate with your content.'
+options:
+  -
+    name: max_items
+    type: integer
+    required: false
+    description: 'The maximum number of items that may be selected.'
+stage: 'Writing the Draft'
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607012515
+id: f41ba1b1-95e3-429b-8295-f812f5cd9e0d
+---
+## Overview
+
+Use this fieldtype to create a one-way relationship with a form in your site. It’s delightfully simple. It points to the `resources/forms` directory and will list all available forms therein.

--- a/content/collections/fieldtypes/html.md
+++ b/content/collections/fieldtypes/html.md
@@ -1,0 +1,9 @@
+---
+title: HTML
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607014272
+stage: 'Gathering Knowledge'
+intro: 'An HTML field so you can write HTML to display as HTML, which can be used to display links to edit blueprints from configure screens.'
+id: 0a8e9c40-acee-4d4c-a042-e99590632439
+published: false
+---

--- a/content/collections/fieldtypes/sites.md
+++ b/content/collections/fieldtypes/sites.md
@@ -1,0 +1,10 @@
+---
+title: Sites
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607014262
+intro: 'Choose a site. Useful in multi-site setups'
+stage: 'Gathering Knowledge'
+id: 1058a198-4175-47cf-90fd-460101ca1506
+published: false
+---
+pulls from `config/statamic/sites.php`

--- a/content/collections/fieldtypes/structures.md
+++ b/content/collections/fieldtypes/structures.md
@@ -1,0 +1,9 @@
+---
+title: Structures
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607014332
+intro: 'Choose one of your structures to relate with your content.'
+stage: 'Gathering Knowledge'
+id: 423097a1-f861-4631-b822-c20014c2d923
+published: false
+---

--- a/content/collections/fieldtypes/taggable.md
+++ b/content/collections/fieldtypes/taggable.md
@@ -1,11 +1,14 @@
 ---
-title: Tags
+title: Taggable
 screenshot: fieldtypes/tags.png
-description: Enter a list of items with a tag-style interface.
-overview: >
-  Users can enter “taggable” values, which are formatted
-  automatically into a YAML list format. It's a lot like the [list fieldtype](/fieldtypes/list) but with a different UI.
+description: 'Enter a list of items with a tag-style interface.'
+overview: |
+  Users can enter “taggable” values, which are formatted automatically into a YAML list format. It's a lot like the [list fieldtype](/fieldtypes/list) but with a different UI.
+  
 stage: 4
+template: page
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607013600
 id: 821a636f-2ebd-4297-b459-47e702f899df
 ---
 ## Overview

--- a/content/collections/fieldtypes/taxonomies.md
+++ b/content/collections/fieldtypes/taxonomies.md
@@ -1,0 +1,9 @@
+---
+title: Taxonomies
+intro: 'Choose one of your taxonomies, not the terms, to relate with your content.'
+stage: 'Gathering Knowledge'
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607015037
+id: a19dfb96-2c54-4eb9-a024-eb9cc0effab1
+published: false
+---

--- a/content/collections/fieldtypes/user-groups.md
+++ b/content/collections/fieldtypes/user-groups.md
@@ -1,0 +1,14 @@
+---
+title: 'User Groups'
+intro: 'Choose one of your User Groups to relate with your content. `pro only`'
+stage: 'Gathering Knowledge'
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607014907
+id: fad57d63-f7c1-49c0-b2d2-e9e4d38a5887
+published: false
+---
+## Overview
+
+Used to assing a User to a particular User Group. It pulls from `resources/users/groups.yaml` directory and will list all available groups.
+
+> This is a pro feature and is generally only used on User blueprints, you should read about [taxonomies](/users#user-groups).

--- a/content/collections/fieldtypes/user-roles.md
+++ b/content/collections/fieldtypes/user-roles.md
@@ -1,0 +1,15 @@
+---
+title: 'User Roles'
+intro: 'Choose one of your User Roles to relate with your content. `pro only`'
+stage: 'Gathering Knowledge'
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1607014821
+template: page
+id: 6734fdc7-6d43-49b2-b3fb-cfd3d6f45878
+published: false
+---
+## Overview
+
+This is generally used as a “system” field to control a user's permissions. It pulls from `resources/users/roles.yaml` directory and will list all available roles.
+
+> This is a pro feature and is generally only used on User blueprints, you should read about [taxonomies](/users#permissions).


### PR DESCRIPTION
This is an effort to sync up the `Create Field` options with the Fieldtypes shown in the docs. Since there are more options available when adding a field than are shown in the docs, it can be confusing to know which is the right one. 

There are a few different parts here, that may need to be broken out:

1. Added the Form fieldtype as a published entry (but without a screenshot) so it would be in the Everything Else group. This one seemed more straightforward and worth publishing (as opposed to group 2)
2. Created unpublished entries for the remaining fieldtypes that are available to the user, but not seen in the docs. All of these tend to be relate inputs that refer to non-content (ie Structures, User Groups, Sites, etc.). Most are pretty self-explanatory and likely don't need much explaining. 
    - I wasn't sure what to do with User Groups/User Roles since they are technically Pro features. Figured you might have a better solution in mind.

3. I really wasn't sure what the HTML fieldtype is for. It's not like the others in group 2, but still unpublished.
4. I wanted to rename `Tags => Taggable` since that is the option in the cp. Goal was just to have them be in sync so its easier for anyone trying to look them up. Obviously, could also change the cp list from `Taggable => Tags` to reflect the docs.