### PR TITLE
Change `filter` to `visibleTo`

### DIFF
--- a/content/collections/extending-docs/actions.md
+++ b/content/collections/extending-docs/actions.md
@@ -71,18 +71,18 @@ public function boot()
 
 ## Filtering Actions
 
-You may limit which items an action can be applied to using the `filter` method. For example, if you want your action to only be used by entries, you can return a boolean like this:
+You may limit which items an action can be applied to using the `visibleTo` method. For example, if you want your action to only be used by entries, you can return a boolean like this:
 
 ``` php
 use Statamic\Contracts\Entries\Entry;
 
-public function filter($item)
+public function visibleTo($item)
 {
     return $item instanceof Entry;
 }
 ```
 
-> Don't include authorization in your filter method. Instead, use the authorize method below.
+> Don't include authorization in your `visibleTo` method. Instead, use the authorize method below.
 
 ## Authorizing Actions
 


### PR DESCRIPTION
In the documentation about [creating a custom action](https://statamic.dev/extending/actions#filtering-actions), it references an old `filter` method which has since been renamed to `visibleTo`. This PR just fixes that.

It was pointed out in [this Forum post](https://statamic.com/forum/5067-filter-method-on-custom-actions-cp)