### PR TITLE
Fix file name and array for sort parameters in locales tag docs

### DIFF
--- a/content/collections/tags/locales.md
+++ b/content/collections/tags/locales.md
@@ -14,7 +14,7 @@ parameters:
     name: sort
     type: string
     description: |
-      Sort by one of the keys in your `system.yaml`'s `locales` array. (eg. `name` or `full`). If left blank, the order in the file will be maintained. Only applicable in the tag pair.
+      Sort by one of the keys in your `sites.php`'s `sites` array. (eg. `name` or `full`). If left blank, the order in the file will be maintained. Only applicable in the tag pair.
   -
    name: current_first
    type: boolean *true*


### PR DESCRIPTION
I got confused while reading the docs for the locales tag. It still had the V2 system.yaml and the locales array referenced un der the sort parameter info. Changed to sites.php and sites array under the sort parameter...