### PR TITLE
`results` is not needed

### DIFF
--- a/content/collections/docs/taxonomies.md
+++ b/content/collections/docs/taxonomies.md
@@ -129,9 +129,7 @@ When on a [taxonomy route](#routing), you can list the terms by using a `terms` 
 ```
 {{ terms }}
   <ul>
-  {{ results }}
     <li><a href="{{ url }}">{{ title }}</a></li>
-  {{ /results }}
   </ul>
 {{ /terms }}
 ```
@@ -145,9 +143,7 @@ When on a [term route](#routing), you can list the entries by using an `entries`
 ```
 {{ entries paginate="5" }}
   <ul>
-  {{ results }}
     <li><a href="{{ url }}">{{ title }}</a></li>
-  {{ /results }}
   </ul>
 {{ /entries }}
 ```

--- a/content/collections/docs/taxonomies.md
+++ b/content/collections/docs/taxonomies.md
@@ -143,7 +143,9 @@ When on a [term route](#routing), you can list the entries by using an `entries`
 ```
 {{ entries paginate="5" }}
   <ul>
+  {{ results }}
     <li><a href="{{ url }}">{{ title }}</a></li>
+  {{ /results }}
   </ul>
 {{ /entries }}
 ```


### PR DESCRIPTION
If you use the examples as listed they don't work because there is no `results`.