### PR TITLE
Add a note to the from paramater for the nav tag

### DIFF
--- a/content/collections/tags/nav.md
+++ b/content/collections/tags/nav.md
@@ -15,7 +15,7 @@ parameters:
   -
     name: from
     type: string
-    description: "The starting point for your navigation. If unspecified, it'll start from the top."
+    description: "The starting point for your navigation. If unspecified, it'll start from the top. Note: this parameter is only supported for orderable collections."
   -
     name: show_unpublished
     type: 'boolean *false*'


### PR DESCRIPTION
Make it clear that the `from` parameter is only supported when using orderable collections.

**See:** https://github.com/statamic/cms/issues/3049