### PR TITLE
Document where to configure language(s) used by the `iso_format` modifier

### DIFF
--- a/content/collections/modifiers/iso_format.md
+++ b/content/collections/modifiers/iso_format.md
@@ -6,6 +6,8 @@ id: f72ffc08-4294-4c1c-9085-2794ee57962d
 ---
 Given a date string, or anything that even sorta kinda looks like a date string, will convert it to a [Carbon][carbon] instance and allow you to format it with ISO format. This allows you to use inner translations rather than language packages you need to install on every machine where you deploy your site.
 
+The language that will be used for translations depends on what you configured in your `config/statamic/sites.php` file. The `locale` and `fallback_locale` settings from the `config/app.php` file have **no influence** on this modifier.
+
 This is also compatible with [momentjs format method](https://momentjs.com/), it means you can use same format strings as you may have used in moment from your front-end or other node.js application.
 
 Check out the [complete list of available replacements](https://carbon.nesbot.com/docs/#iso-format-available-replacements).


### PR DESCRIPTION
It took me a while to figure this out, because I was wondering why date translations were not taking my `locale` into account… So I thought it would be nice if I could avoid some frustrations to other beginners like me.

Feel free to change the wording, but I think it would be quite helpful to explicitly say that the language has to be configured in the `config/statamic/sites.php` config file. Being experienced with Laravel, it totally made sense to me to expect the framework’s `locale` setting to be taken into account by Statamic’s `iso_format` modifier, and the docs said nothing to prevent me from going in this wrong direction.