### PR TITLE
Important note on cached config

### DIFF
--- a/content/collections/docs/installation.md
+++ b/content/collections/docs/installation.md
@@ -76,6 +76,8 @@ After Statamic is installed, you'll have the `content/`, `users/`, and `config/s
 
 Your explicit routes will take precedence and anything not caught by your app will run through Statamic and will work as documented. Enjoy!
 
+Make sure your Laravel config is *not* cached before installing Statamic. If you're not sure run `php artisan config:clear`.
+
 ## Next Steps
 
 Once you've installed Statamic, you're ready to start building! Check out the [Quick Start](/quick-start) page for a walkthrough on how to build a simple site, access the Control Panel, creating a user, and more.


### PR DESCRIPTION
When you install Statamic into an existing Laravel app, you might break your production site if you do not delete the cached config before the first Statamic installation.