### PR TITLE
Add routing tip for new collections

### DIFF
--- a/content/collections/docs/collections.md
+++ b/content/collections/docs/collections.md
@@ -138,6 +138,8 @@ route:
   french: /evenements/{slug}
 ```
 
+> When creating new collections, Statamic doesn't automatically define a default route rule. If you want entries in your new collection to receive URLs, make sure you define a route rule!
+
 ### Meta variables
 
 | Variable | Available |


### PR DESCRIPTION
Adds a tip pointing out that Statamic doesn't use a default route rule for new collections.

This is probably obvious to most people—but for some who are coming from different ecosystems, or who sometimes forget their common sense (like me), it might help save a few minutes of confusion.