### PR TITLE
Update widgets.md

### DIFF
--- a/content/collections/docs/widgets.md
+++ b/content/collections/docs/widgets.md
@@ -39,6 +39,7 @@ Display a listing of form submissions.
 [
 	'type' => 'form',
 	'form' => 'contact', // name of your form
+    'fields' => ['name','email'], // the fields you want to display in the widget
 	'width' => 100,
 	'limit' => 10
 ]
@@ -74,6 +75,7 @@ Will display if updates are available
     [
         'type' => 'form',
         'form' => 'contact',
+        'fields' => ['name','email'],
         'width' => 100,
         'limit' => 20,
     ],


### PR DESCRIPTION
The forms widget loops over `fields` (`@foreach($fields as $key => $field)`). Yet when using the current example you only see the date submitted column.

I just wasted half an hour resaving my yaml files and other settings thinking that it was some issue related to that. To discover that in order to display the fields you need to specify them in the config. I was under impression that the listable param would be used for this.