### PR TITLE
Update structures.md - Broken Link

### DIFF
--- a/content/collections/docs/structures.md
+++ b/content/collections/docs/structures.md
@@ -54,7 +54,7 @@ Freestyle navigation structures exist to manage a nav out of existing entries, a
 
 ## Templating
 
-You can work with the [structure tag](/tags/structure) to loop through and render your HTML with its links. For backwards compatibility, the [nav tag](/tags/nav) will reference a default "Pages" collection structure, if there is one.
+You can work with the structure tag to loop through and render your HTML with its links. For backwards compatibility, the [nav tag](/tags/nav) will reference a default "Pages" collection structure, if there is one.
 
 ```
 <ul>


### PR DESCRIPTION
Removed "structure tag" link since it is broken. I couldn't find a "Structure Tag" page in the docs.