### PR TITLE
explains how events can be suppressed with saveQuietly()

### DIFF
--- a/content/collections/extending-docs/data.md
+++ b/content/collections/extending-docs/data.md
@@ -74,8 +74,7 @@ $entry->save();
 Now it’ll be written to file. Nice.
 
 ### Events
-When you are saving your data instance, the `Statamic\Events\EntrySaving` and `Statamic\Events\EntrySaved` events are dispatched.  
- In some cases, you would rather suppress those events. For example, to prevent causing an infinite loop of `EntrySaved` events. 
+When you are saving or creating your data instance, the `EntrySaving`, `EntryCreated` and the `EntrySaved` events are dispatched.  In some cases, you would rather suppress those events. For example, to prevent causing an infinite loop of `EntrySaved` events. 
 ``` php
 $entry->saveQuietly();
 ```

--- a/content/collections/extending-docs/data.md
+++ b/content/collections/extending-docs/data.md
@@ -73,6 +73,12 @@ $entry->save();
 
 Now it’ll be written to file. Nice.
 
+### Events
+When you are saving your data instance, the `Statamic\Events\EntrySaving` and `Statamic\Events\EntrySaved` events are dispatched.  
+ In some cases, you would rather suppress those events. For example, to prevent causing an infinite loop of `EntrySaved` events. 
+``` php
+$entry->saveQuietly();
+```
 
 ## Creating Data
 

--- a/content/collections/extending-docs/live-preview.md
+++ b/content/collections/extending-docs/live-preview.md
@@ -14,7 +14,7 @@ Out of the box, Statamic will push the temporary version of the entry through it
 
 If you have complex requirements – for example, needing to render it through a different frontend – you are able to customize it.
 
-The `LocalizedEntry` class has a `toLivePreviewResponse` method. You can override this and return whatever you want to be
+The `Entry` class has a `toLivePreviewResponse` method. You can override this and return whatever you want to be
 rendered in Live Preview's content pane.
 
 [See how to override the entry classes.](/extending/repositories#custom-data-classes)
@@ -24,9 +24,9 @@ rendered in Live Preview's content pane.
 
 namespace App;
 
-use Statamic\Data\Entries\LocalizedEntry as BaseLocalizedEntry;
+use Statamic\Entries\Entry;
 
-class LocalizedEntry extends BaseLocalizedEntry
+class YourCustomEntry extends Entry
 {
     public function toLivePreviewResponse($request, $extra)
     {


### PR DESCRIPTION
Since i wrote the saveQuietly() method, I'd like to show it in the docs, so other devs can make use of it.