### PR TITLE
Update yaml.md - Typos in Collections

### DIFF
--- a/content/collections/docs/yaml.md
+++ b/content/collections/docs/yaml.md
@@ -118,7 +118,7 @@ Booleans in YAML are expressed with `true` and `false`.
 
 ## Collections
 
-YAML collections can be a sequence (or list)Arrays are lists of values. They can be formatted like a plain-text bulleted list or comma delimited inside brackets, similar to JSON.
+YAML collections can be a sequence (or list). Arrays are lists of values. They can be formatted like a plain-text bulleted list or comma delimited inside brackets, similar to JSON.
 
 ```.language-yaml
 # These are both valid YAML arrays
@@ -130,7 +130,7 @@ to_buy:
 to_sell: [aloe vera, winter coat, mittens]
 ```
 
-To render the values from a YAML array
+To render the values from a YAML array:
 
 
 ### Element Map


### PR DESCRIPTION
- Added period at end of "YAML collections can be a sequence (or list)". Is this how you wanted it worded?
- Added colon to end of "To render the values from a YAML array".