### PR TITLE
Fix naming of field for TermBlueprintFound event

### DIFF
--- a/content/collections/extending-docs/events.md
+++ b/content/collections/extending-docs/events.md
@@ -498,7 +498,7 @@ An example of when this would be useful is to add a section to a blueprint in th
 public function handle(TermBlueprintFound $event)
 {
     $event->blueprint;
-    $event->entry;
+    $event->term;
 }
 ```
 


### PR DESCRIPTION
The property is actually called `term`, not `entry` (probably a copy & paste error from `EntryBlueprintFound`).

See [`TermBlueprintFound:8`](https://github.com/statamic/cms/blob/9b4e5915ffdddef154274c98a475f8644f9669f8/src/Events/TermBlueprintFound.php#L8)