### PR TITLE
Document custom CP Nav Icons

### DIFF
--- a/content/collections/extending-docs/navigation.md
+++ b/content/collections/extending-docs/navigation.md
@@ -40,6 +40,17 @@ Nav::extend(function ($nav) {
 });
 ```
 
+If you wish to use a custom SVG or one from the [Streamline Icon Pack](https://streamlineicons.com/) that's not included in Statamic, you may pass the SVG icon to the `icon()` method, in place of an icon name.
+
+```php
+Nav::extend(function ($nav) {
+    $nav->create('Store')
+        ->section('Jack & Sons Inc.')
+        ->route('store.index')
+        ->icon('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.547 9.674l7.778 7.778a4.363 4.363 0 0 0 .9-4.435l5.965-5.964.177.176a1.25 1.25 0 0 0 1.768-1.767l-4.6-4.6a1.25 1.25 0 0 0-1.765 1.771l.177.177-5.965 5.965a4.366 4.366 0 0 0-4.435.899zM10.436 13.563L.5 23.499" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/></svg>');
+});
+```
+
 > Note that the `Nav` facade is `Statamic\Facades\CP\Nav`.
 >
 > There's another Nav facade without the CP namespace - that one's for the front-end ["Navs"](/navigation) feature.


### PR DESCRIPTION
Just realised that I never added any documentation for one of my PRs, statamic/cms#2890, which allows you to pass in a custom SVG icon as a string, rather than an icon name to the `icon()` method.