### PR TITLE
Update nav.md

### DIFF
--- a/content/collections/tags/nav.md
+++ b/content/collections/tags/nav.md
@@ -77,6 +77,12 @@ variables:
       being viewed. Also useful for outputting
       active states.
   -
+    name: is_external
+    type: boolean
+    description: >
+      Whether the current nav URL is an external link . Useful for outputting
+      `target=_"blank"` in menu templates.      
+  -
     name: depth
     type: integer
     description: The depth of the page within the nav structure.


### PR DESCRIPTION
Document `is_current` property

The only way to find out that `is_current` can be used to easily modify navigation behavior for external links (i.e. adding `target="_blank"`) was through dumping variables. This should be documented imho.