### PR TITLE
Add multi-site explanation to cache strategies

### DIFF
--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -220,4 +220,24 @@ return [
 ];
 ```
 
+
+## File Locations for Multi-Sites
+
+When using multi-site you can override the path with an array of your sites, usefull when using multiple root domains per site.
+
+``` php
+return [
+
+    'strategies' => [
+        'full' => [
+            'driver' => 'file',
+            'path' => [
+               'default'    => public_path('static') . '/default',
+               'other_site' => public_path('static') . '/other_site',
+            ]
+        ]
+    ]
+];
+```
+
 You will need to update your appropriate server rewrite rules.


### PR DESCRIPTION
Especially when using root domains eg test.nl, and test.de you get duplicates when using just one path

With the explanation of the array path property one can use a path per site (already supported but hard to find)