### PR TITLE
Nav:breadcrumbs tag: Clarify the meaning of the include_home parameter

### DIFF
--- a/content/collections/tags/nav-breadcrumbs.md
+++ b/content/collections/tags/nav-breadcrumbs.md
@@ -9,7 +9,7 @@ parameters:
     name: include_home
     type: 'boolean'
     description: >
-      Remove the home page and begin from the first level nav item. Default: `true`.
+      Include the home page as the first breadcrumb. Default: `true`.
   -
     name: reverse
     type: 'boolean'


### PR DESCRIPTION
Currently the docs for the `nav:breadcrumbs` tag claim that the `include_home` parameter *removes* the home page. That doesn't make sense: it *adds* the home page to the beginning of the breadcrumbs. This PR changes the description of the parameter to reflect this.