### PR TITLE
Clarify other fields can be used for template variable

### DIFF
--- a/content/collections/docs/views.md
+++ b/content/collections/docs/views.md
@@ -65,7 +65,7 @@ template: gallery
 title: Photo Gallery
 ```
 
-> You can use the [template](/fieldtypes/template) fieldtype to make choosing your template in any entry easy.
+> You can use the [template](/fieldtypes/template) fieldtype to make choosing your template in any entry easy. Any [fieldtype](/fieldtypes) that returns a string like in the example above works too, so go wild!
 
 ## Partials
 


### PR DESCRIPTION
Doesn't directly fix #262, but adds clarification that other fieldtypes (including hidden) can be used too.