### PR TITLE
Extend the nav:breadcrumbs documentation with a multisite caveat.

### DIFF
--- a/content/collections/tags/nav-breadcrumbs.md
+++ b/content/collections/tags/nav-breadcrumbs.md
@@ -59,3 +59,37 @@ Here's an example of what breadcrumbs might look like, as well as a code example
     {{ /nav:breadcrumbs }}
 </ul>
 ```
+
+## Multisite caveats
+
+If you find some of your crumbs appear to have been eaten by a ghost, and they don't show up for you, read on.
+
+<figure>
+    <div class="flex font-mono">
+      <div class="mr-4 text-pink-hot font-bold">Cómo vestirse como David Hasselhoff</div>
+    </div>
+    <figcaption>¿Dónde está mi home y blog?</figcaption>
+</figure>
+
+What's happening is that one or more of the parent pages (of the current page) have not been translated in your current site. In the example above, the 'blog' collection and the Spanish homepage have not been translated into Spanish.
+
+> Breadcrumbs get created based on the URL, which is necessary for it to flexible. You could, after all, go in and out of collections, custom routes...
+
+If you visit `/spanish/blog/como-vestirse-como-david-hasselhof`,
+
+- First it looks for an entry with a url of `/spanish/blog/como-vestirse-como-david-hasselhof`
+- Then it pops the last segment off (`como-vestirse-como-david-hasselhof`) and looks for an entry with a url of `/spanish/blog`
+- Rinse and repeat until it's out of segments, so next is `spanish`.
+
+So to make the blog appear in the Spanish breadcrumbs, we have to translate the `/spanish/blog` page, and the Spanish homepage after which the missing breadcrumb will appear.
+
+<figure>
+    <div class="flex font-mono">
+      <div class="mr-4">Home</div>
+      <div class="mr-4">&rarr;</div>
+      <div class="mr-4">Blog</div>
+      <div class="mr-4">&rarr;</div>
+      <div class="mr-4 text-pink-hot font-bold">Cómo vestirse como David Hasselhoff</div>
+    </div>
+    <figcaption>¡Perfecto!</figcaption>
+</figure>


### PR DESCRIPTION
I've added some extra documentation for the `nav:breadcrumbs` tag, as I understand it explained [by Jason](https://github.com/statamic/cms/issues/3523#issuecomment-819146401).

Closes #436