### PR TITLE
Update oauth.md. Missing service provider when adding additional socialite providers.

### DIFF
--- a/content/collections/docs/oauth.md
+++ b/content/collections/docs/oauth.md
@@ -108,6 +108,16 @@ Require the appropriate provider using Composer:
 composer require socialiteproviders/dropbox
 ```
 
+Ensure the `SocialiteProviders\Manager\ServiceProvider` is present in `config/app.php`:
+
+```php
+'providers' => [
+    // (...)
+    SocialiteProviders\Manager\ServiceProvider::class,
+    // (...)
+];
+```
+
 Add the event listener to your EventServiceProvider:
 
 ``` php


### PR DESCRIPTION
Add a missing step needed for the SocialiteWasCalled event to be ever called.