### PR TITLE
Adding missing braces

### DIFF
--- a/content/collections/tags/nav.md
+++ b/content/collections/tags/nav.md
@@ -156,7 +156,7 @@ Use the `uri` to get the children of the current page.
 
 ```
 <ul>
-    {{ nav :from="uri" }}
+    {{ nav :from="{uri}" }}
         {{ unless no_results }}
             <li>
                 <a href="{{ url }}">{{ title }}</a>


### PR DESCRIPTION
The uri has to be wrapped in braces otherwise it doesn't work.