### PR TITLE
Using new route syntax

### DIFF
--- a/content/collections/docs/controllers.md
+++ b/content/collections/docs/controllers.md
@@ -20,7 +20,9 @@ Anything you can do in Laravel you can do here. Because you're using Laravel. Yo
 For example, you can map a `GET` request to `yoursite.com/example` to the `index` method in the `app\Http\Controllers\ExampleController.php` file like this:
 
 ``` php
-Route::get('example', 'ExampleController@index');
+use App\Http\Controllers\ExampleController;
+
+Route::get('example', [ExampleController::class, 'index']);
 ```
 
 ## Basic Controller


### PR DESCRIPTION
old syntax throws `Target class [ExampleController] does not exist.` error.