### PR TITLE
Fixing typo : secect -> select

### DIFF
--- a/content/collections/docs/quick-start.md
+++ b/content/collections/docs/quick-start.md
@@ -144,7 +144,7 @@ You can add any title you like in the `title` box based on search engine optimiz
 
 Next, add a catchy description in the `content` box, something like "The greatest professional wrestling fan site, OOOOH YEAAAH!"
 
-Now, scroll down to Template. From the drop down we have several options. We used "home" for our Home page, now let's secect "default" for our About page.
+Now, scroll down to Template. From the drop down we have several options. We used "home" for our Home page, now let's select "default" for our About page.
 
 Click **Save & Publish** and you'll see your new page titled "About" in the List.
 


### PR DESCRIPTION
Fixed a typo encountered while working through the quick start.

> now let's _secect_ "default" for our About page. 

should be 

> now let's _select_ "default" for our About page.