### PR TITLE
Replace relate tag reference with get_content

### DIFF
--- a/content/collections/modifiers/get.md
+++ b/content/collections/modifiers/get.md
@@ -7,7 +7,7 @@ modifier_types:
 id: c6311d04-364d-4086-8b6b-2a58e88c6cb8
 ---
 Gets a value from a relationship based on its ID. This is like a nicer-to-read single tag version of the
-[Relate Tag](/tags/relate).
+[Get_Content Tag](/tags/get_content).
 
 ``` .language-yaml
 featured_post: 4e82a520-275f-11e6-bdf4-0800200c9a66
@@ -24,5 +24,7 @@ Featured Post Title
 The above is equivalent to doing this:
 
 ```
-{{ relate:featured_post }}{{ title }}{{ /relate:featured_post }}
+{{ get_content :from="featured_post" }}
+    {{ title }}
+{{ /get_content }}
 ```


### PR DESCRIPTION
Since the relate tag doesn't exist anymore in v3. 
