### PR TITLE
Command/Ctrl+K keybind that focuses on search input

### DIFF
--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -17,8 +17,25 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
     <link rel="stylesheet" href="{{ mix src='/css/tailwind.css' }}">
     <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
+    <script>
+        function bodyData() {
+            let primaryKeyBind = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? 'meta' : 'ctrl';
+            return {
+                showNav: false,
+                showEasterEgg: false,
+                bindings: {
+                    ['@keydown.slash.prevent']() {
+                        this.$refs.docsSearch.focus();
+                    },
+                    ['@keydown.' + primaryKeyBind + '.k.prevent']() {
+                        this.$refs.docsSearch.focus();
+                    }
+                }
+            };
+        }
+    </script>
 </head>
-<body class="text-blue-darkest leading-normal language-antlers" x-data="{ showNav: false, showEasterEgg: false }" @keydown.slash.prevent="$refs.docsSearch.focus()">
+<body class="text-blue-darkest leading-normal language-antlers" x-data="bodyData()" x-spread="bindings">
 
 {{ partial:partials/nav }}
 

--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
     <link rel="stylesheet" href="{{ mix src='/css/tailwind.css' }}">
     <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
-    <script>
+    <script type="text/javascript">
         function bodyData() {
             let primaryKeyBind = /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? 'meta' : 'ctrl';
             return {


### PR DESCRIPTION
Switching between Tailwind and Statamic docs I found it frustrating that there was no CTRL+K binding to focus on the search input.

Borrowed/inspired from how Tailwind does it in their docs. https://github.com/tailwindlabs/tailwindcss.com/blob/7617a606ee89065144bcfe3e6b35d2938e707c0a/src/components/Search.js

Moved the Alpine x-data outside to <script> tag because I could not figure out how to dynamically create a keybind.

Unfortunately can't test if it works on MacOS as intended.

