### PR TITLE
Use less generic set types to make Bard looping example clearer

### DIFF
--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -104,18 +104,22 @@ Use tag pair syntax with `if/else` conditions to style each set accordingly.
 ```
 {{ bard_field }}
 
-  {{ if type == "text" }}
+  {{ if type == "poll" }}
 
-    <div class="text">
-      {{ text }}
-    </div>
-
-  {{ elseif type == "image" }}
-
-    <figure>
-      <img src="{{ image }}" alt="{{ caption }}" />
-      <figcaption>{{ caption }}</figcaption>
+    <figure class="poll">
+      <figcaption>{{ question }}</figcaption>
+      <ul>
+        {{ options }}
+          <li>{{ text }}</li>
+        {{ /options }}
+      </ul>
     </figure>
+
+  {{ elseif type == "hero_image" }}
+
+    <div class="heroimage">
+      <img src="{{ hero_image }}" alt="{{ caption }}" />
+    </div>
 
   {{ /if }}
 
@@ -133,9 +137,8 @@ An alternative approach (for those who like DRY or small templates) is to create
 ``` files
 resources/views/partials/sets/
 |-- gallery.antlers.html
-|-- image.antlers.html
+|-- hero_image.antlers.html
 |-- poll.antlers.html
-|-- text.antlers.html
 `-- video.antlers.html
 ```
 


### PR DESCRIPTION
It may seem insignificant but I think this can be beneficial for those people (like me) who scour the docs by looking at the example codes instead of reading the whole page. The set examples like "text" and "image" are in my opinion too generic that it can lead you to think that you can loop through normal rich text editor nodes, which you cannot currently.

PR is inspired by this situation https://discord.com/channels/489818810157891584/489819906540568593/844982271605866536

Let me know what you think.