### PR TITLE
Document Bard text type, recommend using Tailwind typography plugin

### DIFF
--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -97,9 +97,11 @@ If you are using Bard just as a rich text editor and have no need for sets you w
 {{ bard_field }}
 ```
 
+> To style the output of rich text editor on front-end, we recommend using [TailwindCSS typography](https://github.com/tailwindlabs/tailwindcss-typography) plugin.
+
 ### With Sets
 
-Use tag pair syntax with `if/else` conditions to style each set accordingly.
+Use tag pair syntax with `if/else` conditions to style each set accordingly. A conditional for `text` type can be added to handle the rich text editor content between the sets.
 
 ```
 {{ bard_field }}


### PR DESCRIPTION
Continuing from here: https://github.com/statamic/docs/pull/472

1. Documented the `text` type so it is clearer that it is the content between the sets and not another set.
2. Guide the developer in right direction on how to style rich text editor content by recommending Tailwind typography plugin.  I hope this reduces instances where a developer might think about styling each individual node. While Erin did point out that it is possible to style each node, it seems like an approach that should not be recommended in the docs.