### PR TITLE
fix oauth callback method name

### DIFF
--- a/content/collections/docs/oauth.md
+++ b/content/collections/docs/oauth.md
@@ -154,7 +154,7 @@ You may customize how it's done by adding a callback to your `AppServiceProvider
 
 ### User data
 
-The only data added to the user will be their `name`. If you would like to customize what gets created, you can return an array from the provider's `withUser` callback. The closure will be given an instance of `Laravel\Socialite\Contracts\User`.
+The only data added to the user will be their `name`. If you would like to customize what gets created, you can return an array from the provider's `withUserData` callback. The closure will be given an instance of `Laravel\Socialite\Contracts\User`.
 
 ``` php
 use Statamic\Facades\OAuth;


### PR DESCRIPTION
The paragraph mentions `withUser` method name, while in fact the `withUserData` is both a valid name and the one used in an example.