### PR TITLE
Update bard docs for custom extensions

### DIFF
--- a/content/collections/extending-docs/bard.md
+++ b/content/collections/extending-docs/bard.md
@@ -46,6 +46,26 @@ export default class MyExtension {
   name() {
     return 'myextension';
   }
+  
+  schema() {
+    // Your schema stuff
+  }
+  
+  commands({type}) {
+    // Your command stuff
+  }
+
+  inputRules({type}) {
+    return [] // Input rules if you want
+  }
+
+  plugins() {
+    return []
+  }
+
+  pasteRules() {
+    return []
+  }
 }
 ```
 


### PR DESCRIPTION
It seems necessary to have all listed methods, even if returning an empty array.

Not having those did throw errors on my end, which I couldn't connect to the real problem. Adding this in the docs would make the dev experience much nicer and would have saved me some hours. 

Not making those methods required in the core would be a different approach.