### PR TITLE
Glide: Extend description for quality property

### DIFF
--- a/content/collections/tags/glide.md
+++ b/content/collections/tags/glide.md
@@ -66,7 +66,7 @@ shape:
     name: quality
     type: integer
     description: >
-      Defines the quality of the image. Use values between `0` and `100`. Only relevant if the format is `jpg` or `pjpg`. Default: `90`.
+      Defines the quality of the image. Use values between `0` and `100`. Only relevant if the format is `jpg`, `pjpg` or `webp`. Default: `90`.
   -
     name: dpr
     type: integer


### PR DESCRIPTION
Add webp to the list of formats which are affected by quality.

This is not documented in [the glide docs](https://glide.thephpleague.com/2.0/api/encode/#quality-q), but I just tested it, and `webp` is also affected by `quality`.