### PR TITLE
Added a tip to clear the stache cache

### DIFF
--- a/content/collections/extending-docs/repositories.md
+++ b/content/collections/extending-docs/repositories.md
@@ -84,4 +84,4 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
-> You should clear your cache after changing a binding like this.
+> Don't forget to run `php please stache:clear`, for the new bindings to take effect.


### PR DESCRIPTION
After chatting on Discord with @jasonvarga (https://discord.com/channels/489818810157891584/489819906540568593/864230589052485632), it seems that `php please stache:clear` is required after making any changes to class bindings, otherwise the original Entry class is still used. This change makes this clearer in the docs, hopefully saving other people some time!