### PR TITLE
Clarify save_html option for bard fields

### DIFF
--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -62,7 +62,7 @@ options:
     name: save_html
     type: boolean
     description: >
-      Save HTML instead of structured data. This simplifies – but limits – control of your template markup. Default: `false`.
+      Save HTML instead of structured data. This simplifies – but limits – control of your template markup. Only works in Bard fields with no defined sets. Default: `false`.
   -
     name: always_show_set_button
     type: boolean


### PR DESCRIPTION
In retrospect it should have been obvious that I couldn't have bard fields with sets save as HTML, but it would be a good idea to have it in the docs.