### PR TITLE
Prefix index attribute with colon to support multiple indexes in search:results tag

### DIFF
--- a/content/collections/docs/search.md
+++ b/content/collections/docs/search.md
@@ -69,7 +69,7 @@ Your site's default index includes _only_ the title from from _all_ collections.
 The index you wish you to search can be specified as a parameter on your [search results](#results) tag. You can specify more than one index by delimiting each with a `|` pipe.
 
 ```
-{{ search:results index="docs|articles" }} ... {{ /search:results }}
+{{ search:results :index="docs|articles" }} ... {{ /search:results }}
 ```
 
 ### Searchables


### PR DESCRIPTION
[The docs](https://statamic.dev/search#indexes) mention, that we can provide more than one index to the `serach:results`-tag by delimiting them by a `|`.

```handlebars
{{ search:results index="docs|articles" }} ... {{ /search:results }}
```

However, this doesn't seem to work. I get an `InvalidArgumentException`, as Statamic tries to find a **driver** with the named "docs|articles".

```
InvalidArgumentException
Search index [docs|articles] is not defined. 
```

After taking a dive in the source I figured out that we need to use `:index="docs|articles"` instead of `index="docs|articles"`.

---

I came to this conclusion by following this "line of code"

1. https://github.com/statamic/cms/blob/3.1/src/Search/Tags.php#L30
2. https://github.com/statamic/cms/blob/3.1/src/Tags/Tags.php#L113
3. https://github.com/statamic/cms/blob/3.1/src/Tags/Parameters.php#L18-L22


