### PR TITLE
Remove reference of supporting multiple search indexes in results

### DIFF
--- a/content/collections/docs/search.md
+++ b/content/collections/docs/search.md
@@ -66,10 +66,10 @@ Your site's default index includes _only_ the title from from _all_ collections.
 
 ### Search a specific index
 
-The index you wish you to search can be specified as a parameter on your [search results](#results) tag. You can specify more than one index by delimiting each with a `|` pipe.
+The index you wish you to search can be specified as a parameter on your [search results](#results) tag.
 
 ```
-{{ search:results index="docs|articles" }} ... {{ /search:results }}
+{{ search:results index="docs" }} ... {{ /search:results }}
 ```
 
 ### Searchables


### PR DESCRIPTION
As discovered in https://github.com/statamic/docs/pull/513#issuecomment-887099301, multiple indexes are currently not supported in Statamic v3.
This PR removes the sentence in the docs referencing this feature.