### PR TITLE
Update antlers page which references falsey when it means null

### DIFF
--- a/content/collections/docs/antlers.md
+++ b/content/collections/docs/antlers.md
@@ -300,7 +300,7 @@ If you want to manipulate a variable with [modifiers](/modifiers) before evaluat
 
 ### Variable Fallbacks (Null Coalescence)
 
-When all you need to do is display a variable and set a fallback when it’s falsey, use the null coalescence operator (`??`).
+When all you need to do is display a variable and set a fallback when it’s null, use the null coalescence operator (`??`).
 
 ```
 {{ meta_title ?? title ?? "No Title Set" }}


### PR DESCRIPTION
I was reading the antlers docs at https://statamic.dev/antlers

It mentions using the null coalescence operator when you want to output a fallback:

>When all you need to do is display a variable and set a fallback when it’s **falsey**, use the null coalescence operator (??).

It uses the term `falsey`, which would imply the fallback would be used if the variable was an empty string, an empty array or the integer 0, to name a few.

However, the null coalescence operator doesn't check if the variable is falsey, it checks if it is set and is not null.

So I wanted to propose a very small update to the docs to change this term from `falsey` to `null`. As Antler's vars are initialised to null, we don't need to mention the is set part.

(Looks like similar talk was discussed here: https://github.com/statamic/cms/issues/2986#issuecomment-741471414 - and "falsy" was used to describe the null coaslescence operator, which can be a bit misleading, so I think better to talk about is set and null).