### PR TITLE
Typo: Use correct url for composer website

### DIFF
--- a/content/collections/knowledge-base/command-not-found-statamic.md
+++ b/content/collections/knowledge-base/command-not-found-statamic.md
@@ -2,7 +2,7 @@
 id: 5d5e0add-3e2b-44c9-8ec2-7d18b9965504
 title: 'CLI Command Not Found: Statamic'
 intro: |-
-  In order for you to run globally installed [Composer](https://composer.org) binaries, (like our `statamic` installer) you'll need to tell your computer where it's located.
+  In order for you to run globally installed [Composer](https://getcomposer.org) binaries, (like our `statamic` installer) you'll need to tell your computer where it's located.
 template: page
 categories:
   - cli


### PR DESCRIPTION
http://composer.org/ is not valid. It should be https://getcomposer.org/