### PR TITLE
Use npm ci instead

### DIFF
--- a/content/collections/docs/deploying.md
+++ b/content/collections/docs/deploying.md
@@ -120,7 +120,7 @@ The Deploy Script area is where you'd add commands to install Composer and NPM d
 ``` cli
 cd /home/forge/{example}.{tld}
 git pull origin main
-npm install && npm run production
+npm ci && npm run production
 php please cache:clear
 ```
 


### PR DESCRIPTION
I would suggest using `npm ci` instead of `npm install`:

https://dev.to/visuellverstehen/why-to-use-npm-ci-instead-of-npm-install-mfd