### PR TITLE
Add honeypot field with fallback

### DIFF
--- a/content/collections/docs/forms.md
+++ b/content/collections/docs/forms.md
@@ -112,6 +112,9 @@ This example dynamically renders each input's HTML. You could alternatively writ
                 {{ /if }}
             </div>
         {{ /fields }}
+        
+        // Add the honeypot field
+        <input type="text" class="hidden" name="{{ honeypot ?? 'honeypot' }}">
 
         // This is just a submit button.
         <button type="submit">Submit</button>


### PR DESCRIPTION
If the name for the honeypot field is not explicitly set, Statamic checks for a field named `honeypot`. However, if not set, the `honeypot` variable is `null` instead of the default value `honeypot`. I would imagine that this implicit behavior would be somewhat better understood by the example with a fallback for the variable.