### PR TITLE
findBySlug() requires additional parameter

### DIFF
--- a/content/collections/repositories/entries-repository.md
+++ b/content/collections/repositories/entries-repository.md
@@ -16,7 +16,7 @@ related_entries:
 | `all()` | Get all Entries |
 | `find($id)` | Get Entry by `id` |
 | `findByUri($uri)` | Get Entry by `uri` |
-| `findBySlug($slug)` | Get Entry by `url` |
+| `findBySlug($slug, $handle)` | Get Entry by `url` from `collection-handle` |
 | `query()` | Query Builder |
 | `whereCollection($handle)` | Get Entries in a `Collection` |
 | `whereInCollection([$handles])` | Get all Entries in an array of `Collections` |


### PR DESCRIPTION
I know it's deprecated, but the `findBySlug()` method also requires a collection-handle parameter to be passed along with the slug.