### PR TITLE
Add doc for new inferred templates via `template: '@blueprint'`

### DIFF
--- a/content/collections/docs/views.md
+++ b/content/collections/docs/views.md
@@ -73,6 +73,21 @@ title: Photo Gallery
 You can use the [template](/fieldtypes/template) fieldtype to make choosing your template in any entry easy. Any [fieldtype](/fieldtypes) that returns a string like in the example above works too, so you have a lot of flexibility.
 :::
 
+### Inferring templates from entry blueprints
+
+If you would like to automatically infer collection entry templates from entry blueprints, you can set your collection's default template to `@blueprint`.
+
+``` yaml
+# This would go in your collection's yaml config
+template: '@blueprint'
+```
+
+By doing this, Statamic will look for the corresponding template in `/resources/views/{collection}/{blueprint}.antlers.html`.
+
+For example, if you have an `articles` collection entry that uses a blueprint with the handle of `long`, the `/resources/views/articles/long.antlers.html` template will be used.
+
+Given that this just sets the collection's _default_ entry template, you can still override a template at the entry level as well.
+
 ## Partials
 
 Partials are reusable views that may find themselves in any number of other layouts, templates, and other partials. You can use any view as a partial by using the [partial](/tags/partial) tag.

--- a/content/collections/docs/views.md
+++ b/content/collections/docs/views.md
@@ -75,10 +75,11 @@ You can use the [template](/fieldtypes/template) fieldtype to make choosing your
 
 ### Inferring templates from entry blueprints
 
-If you would like to automatically infer collection entry templates from entry blueprints, you can set your collection's default template to `@blueprint`.
+
+To automatically infer the template from an entry's blueprint, set the collection's default template to `@blueprint`.
 
 ``` yaml
-# This would go in your collection's yaml config
+# collections/{collection}.yaml
 template: '@blueprint'
 ```
 
@@ -86,7 +87,9 @@ By doing this, Statamic will look for the corresponding template in `/resources/
 
 For example, if you have an `articles` collection entry that uses a blueprint with the handle of `long`, the `/resources/views/articles/long.antlers.html` template will be used.
 
-Given that this just sets the collection's _default_ entry template, you can still override a template at the entry level as well.
+:::tip
+You can still set a template on the entry level and override the default.
+:::
 
 ## Partials
 


### PR DESCRIPTION
This documents the new feature added here https://github.com/statamic/cms/pull/4668.

@jackmcdade I put it in the `Views` doc; Not sure if you think it should also go in the `Collections` doc somewhere?

![CleanShot 2021-11-09 at 15 30 10](https://user-images.githubusercontent.com/5187394/140999907-a818d4e6-45fa-420c-bbba-135a52b6d7ed.png)
