### PR TITLE
Link directly to Streamline Light page

### DIFF
--- a/content/collections/extending-docs/navigation.md
+++ b/content/collections/extending-docs/navigation.md
@@ -42,7 +42,7 @@ Nav::extend(function ($nav) {
 });
 ```
 
-If you wish to use a custom SVG or one from the [Streamline Icon Pack](https://streamlineicons.com/) that's not included in Statamic, you may pass the SVG icon to the `icon()` method, in place of an icon name.
+If you wish to use a custom SVG or one from the [Streamline Icon Pack](https://app.streamlinehq.com/icons/streamline-light) that's not included in Statamic, you may pass the SVG icon to the `icon()` method, in place of an icon name.
 
 ```php
 Nav::extend(function ($nav) {


### PR DESCRIPTION
Streamline offer lots of different icon packs now, but the link just goes to the home page. I'm 99% it's Streamline Light, right?