### PR TITLE
Changing link in Hot Tip to the correct tag

### DIFF
--- a/content/collections/tags/markdown.md
+++ b/content/collections/tags/markdown.md
@@ -35,5 +35,5 @@ stage: 5
 ```
 
 :::tip
-Markdown considers indentation to be a code block. You'll need to keep your content flush left or use the [markdown:indentation](/tags/markdown-indentation) tag.
+Markdown considers indentation to be a code block. You'll need to keep your content flush left or use the [markdown:indent](/tags/markdown-indent) tag.
 :::


### PR DESCRIPTION
As found by Nilox:
https://discord.com/channels/489818810157891584/489825364902805505/908586084672364545
