### PR TITLE
Add permalink variable to assets fieldtype docs

### DIFF
--- a/content/collections/fieldtypes/assets.md
+++ b/content/collections/fieldtypes/assets.md
@@ -119,6 +119,7 @@ Inside an asset variable's tag pair you'll have access to the following variable
 |----------|-------------|
 | `url` | Web-friendly URL to the file. |
 | `path` |  Path to the file relative to asset container |
+| `permalink` |  Absolute URL to the file including your site URL. |
 | `basename` | Name of the file with file extension |
 | `blueprint` | Which blueprint is managing the asset container |
 | `container` | Which asset container the file is in |


### PR DESCRIPTION
I find the `permalink` variable very helpful when using the assets fieldtype. Couldn't find any info about the variable in the docs.