### PR TITLE
The Toast facade is in a different namespace.

### DIFF
--- a/content/collections/extending-docs/toast-notifications.md
+++ b/content/collections/extending-docs/toast-notifications.md
@@ -16,7 +16,7 @@ this.$toast.success('message', { duration: 3000 }); // Auto-disappear after this
 You may also trigger these from the server using the `Toast` facade.
 
 ```php
-use Statamic\Facades\Toast;
+use Statamic\Facades\CP\Toast;
 
 Toast::info('message');
 Toast::success('message');


### PR DESCRIPTION
In the docs the Toast facade is supposed to be located in `Statamic\Facades\Toast` but it is actually located in `Statamic\Facades\CP\Toast`