### PR TITLE
Add Swedish to available languages table

### DIFF
--- a/content/collections/docs/cp-translations.md
+++ b/content/collections/docs/cp-translations.md
@@ -39,7 +39,7 @@ preferences:
 | Portuguese | `pt` |
 | Slovene | `sl` |
 | Spanish | `es` |
-| Swedish (*WIP*) | `sv` |
+| Swedish | `sv` |
 
 _Translations are community contributed so may you find them to be incomplete shortly after an update._
 

--- a/content/collections/docs/cp-translations.md
+++ b/content/collections/docs/cp-translations.md
@@ -1,7 +1,7 @@
 ---
 title: 'Control Panel Translations'
 nav_title: Translations
-intro: "Statamic's Control Panel is currently available in 7 languages. We always welcome new translations!"
+intro: "Statamic's Control Panel is currently available in 10 languages. We always welcome new translations!"
 blueprint: page
 id: 79129d32-3f7c-4215-b6b1-21a2fccafa8d
 ---
@@ -39,6 +39,7 @@ preferences:
 | Portuguese | `pt` |
 | Slovene | `sl` |
 | Spanish | `es` |
+| Swedish (*WIP*) | `sv` |
 
 _Translations are community contributed so may you find them to be incomplete shortly after an update._
 


### PR DESCRIPTION
I marked it as Work In Progress, as most of it is still machine translated. Feel free to remove if you want.

I also updated the count of languages at the top of the page.