### PR TITLE
Correct blueprint validate key

### DIFF
--- a/content/collections/docs/blueprints.md
+++ b/content/collections/docs/blueprints.md
@@ -229,7 +229,7 @@ Here's a peek at how that YAML is structured.
   handle: your_field
   field:
     type: text
-    validation:
+    validate:
       - alpha_dash
       - 'min:4'
 ```

--- a/content/collections/docs/fieldtypes.md
+++ b/content/collections/docs/fieldtypes.md
@@ -42,8 +42,8 @@ options:
     description: 'Control whether or not this field is required.'
     required: false
   -
-    name: validation
-    type: boolean
+    name: validate
+    type: array
     description: 'Configure rules that validate the value of this field before allowing the user to save. Learn more about [validation](/blueprints#validation).'
     required: false
 related_entries:


### PR DESCRIPTION
The field key for adding validation rules is `validate`. In some place `validation` was used. Additional the wrong type was documented. Corrected it to array.