### PR TITLE
`ray` modifier missing title

### DIFF
--- a/content/collections/modifiers/ray.md
+++ b/content/collections/modifiers/ray.md
@@ -1,13 +1,15 @@
 ---
 id: 1bb00dc7-f4b2-4bba-aaf9-45e3a2a19518
+blueprint: modifiers
 modifier_types:
   - utility
+title: Ray
+related_entries:
+    - 12de1a6c-e8be-4703-81a3-fc270311bc84
+    - 985dc29c-fe71-464e-bb83-4f3f2aa455c0
 ---
-## Overview
 Send variable to Spatie's [Ray](https://github.com/spatie/laravel-ray). Note, you need to have the Laravel Ray package installed.
 
-## Example
-
-```
+```antlers
 {{ your_field | ray }}
 ```


### PR DESCRIPTION
Removed subtitles **Overview** and **Example**, since it's not present on most other modifier pages.

Also added related entries: 
- `Dump`
- `Console Log`