### PR TITLE
Remove visible {{ noparse }} tags from content

### DIFF
--- a/content/collections/modifiers/hours_ago.md
+++ b/content/collections/modifiers/hours_ago.md
@@ -3,7 +3,6 @@ id: 6ebb6c28-d1f3-4362-92a0-8a16b5c9cd51
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: 'Hours Ago'
 related_entries:
   - e73f1574-732e-4a74-be47-37e1fddb05d6

--- a/content/collections/modifiers/hours_ago.md
+++ b/content/collections/modifiers/hours_ago.md
@@ -19,11 +19,9 @@ Returns the number of hours since a given date variable. Statamic will attempt t
 date: October 1 2015
 ```
 
-{{ noparse }}
 ```
 {{ date | hours_ago }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | hours_ago }}

--- a/content/collections/modifiers/is_today.md
+++ b/content/collections/modifiers/is_today.md
@@ -4,7 +4,6 @@ blueprint: modifiers
 modifier_types:
   - date
   - conditions
-parse_content: true
 title: 'Is Today'
 ---
 Returns `true` if a given date is today, using the server's time.

--- a/content/collections/modifiers/is_yesterday.md
+++ b/content/collections/modifiers/is_yesterday.md
@@ -4,7 +4,6 @@ blueprint: modifiers
 modifier_types:
   - date
   - conditions
-parse_content: true
 title: 'Is Yesterday'
 ---
 Returns `true` if a given date is yesterday, using the server's time.

--- a/content/collections/modifiers/minutes_ago.md
+++ b/content/collections/modifiers/minutes_ago.md
@@ -20,11 +20,9 @@ Returns the number of minutes since a given date variable. Statamic will attempt
 date: October 1 2015 8:30:am
 ```
 
-{{ noparse }}
 ```
 {{ date | minutes_ago }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | minutes_ago }}

--- a/content/collections/modifiers/minutes_ago.md
+++ b/content/collections/modifiers/minutes_ago.md
@@ -3,7 +3,6 @@ id: 06027289-825e-4205-bd3a-f375e26ab81e
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 date: 'October 1 2015 8:30:am'
 title: 'Minutes Ago'
 related_entries:

--- a/content/collections/modifiers/modify_date.md
+++ b/content/collections/modifiers/modify_date.md
@@ -3,7 +3,6 @@ id: 18596c62-5535-41a8-91c4-b5769fb11085
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: 'Modify Date'
 ---
 Alters a timestamp by incrementing or decrementing in a format accepted by PHP's native [`strtotime()`](http://php.net/manual/en/function.strtotime.php) method.

--- a/content/collections/modifiers/months_ago.md
+++ b/content/collections/modifiers/months_ago.md
@@ -3,7 +3,6 @@ id: 7ba53a64-0266-4752-af5b-282a40dd11fa
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: 'Months Ago'
 related_entries:
   - e73f1574-732e-4a74-be47-37e1fddb05d6

--- a/content/collections/modifiers/months_ago.md
+++ b/content/collections/modifiers/months_ago.md
@@ -19,11 +19,9 @@ Returns the number of months since a given date variable. Statamic will attempt 
 date: October 1 2017
 ```
 
-{{ noparse }}
 ```
 {{ date | months_ago }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | months_ago }}

--- a/content/collections/modifiers/relative.md
+++ b/content/collections/modifiers/relative.md
@@ -17,13 +17,11 @@ past_date: October 1 2015
 future_date: October 1 2019
 ```
 
-{{ noparse }}
 ```
 {{ past_date | relative }}
 {{ future_date | relative }}
 {{ past_date | relative:false }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | relative }}

--- a/content/collections/modifiers/relative.md
+++ b/content/collections/modifiers/relative.md
@@ -3,7 +3,6 @@ id: 40578328-3288-4c54-a475-8afad19a37e6
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: Relative
 ---
 Returns a date difference in a nice, human readable, string format. This modifier will add a phrase after the difference value relative to the current date and the passed in date.

--- a/content/collections/modifiers/seconds_ago.md
+++ b/content/collections/modifiers/seconds_ago.md
@@ -3,7 +3,6 @@ id: 603701ba-5da7-4ec8-abe5-5bc9fe6861ea
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: 'Seconds Ago'
 related_entries:
   - e73f1574-732e-4a74-be47-37e1fddb05d6

--- a/content/collections/modifiers/seconds_ago.md
+++ b/content/collections/modifiers/seconds_ago.md
@@ -19,11 +19,9 @@ Returns the number of seconds since a given date variable. Statamic will attempt
 date: October 1 2015 8:30:am
 ```
 
-{{ noparse }}
 ```
 {{ date | seconds_ago }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | seconds_ago }}

--- a/content/collections/modifiers/weeks_ago.md
+++ b/content/collections/modifiers/weeks_ago.md
@@ -19,11 +19,9 @@ Returns the number of weeks since a given date variable. Statamic will attempt t
 date: October 1 2015
 ```
 
-{{ noparse }}
 ```
 {{ date | weeks_ago }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | weeks_ago }}

--- a/content/collections/modifiers/weeks_ago.md
+++ b/content/collections/modifiers/weeks_ago.md
@@ -3,7 +3,6 @@ id: 6fcbfa5c-854e-4541-9955-505eca0d6bf7
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: 'Weeks Ago'
 related_entries:
   - e73f1574-732e-4a74-be47-37e1fddb05d6

--- a/content/collections/modifiers/years_ago.md
+++ b/content/collections/modifiers/years_ago.md
@@ -19,11 +19,9 @@ Returns the number of years since a given date variable. Statamic will attempt t
 date: October 1 2015
 ```
 
-{{ noparse }}
 ```
 {{ date | years_ago }}
 ```
-{{ /noparse }}
 
 ```html
 {{ test_date | years_ago }}

--- a/content/collections/modifiers/years_ago.md
+++ b/content/collections/modifiers/years_ago.md
@@ -3,7 +3,6 @@ id: e73f1574-732e-4a74-be47-37e1fddb05d6
 blueprint: modifiers
 modifier_types:
   - date
-parse_content: true
 title: 'Years Ago'
 related_entries:
   - 603701ba-5da7-4ec8-abe5-5bc9fe6861ea

--- a/content/collections/tags/get_files.md
+++ b/content/collections/tags/get_files.md
@@ -1,6 +1,5 @@
 ---
 title: Get Files
-parse_content: false
 description: Retrieves and filters local files
 intro: The ultimate 🇨🇭Swiss Army Knife doing-stuff-with-files feature. With the `get_files` tag you can scan and display data on files in _any_ directories inside your local filesystem.
 stage: 4

--- a/content/collections/variables/folder.yaml
+++ b/content/collections/variables/folder.yaml
@@ -1,3 +1,2 @@
 order: alphabetical
-parse_content: false
 template: variable


### PR DESCRIPTION
Closes #717

Removed the `{{ noparse }}`s that was being displayed in plain text for some modifiers.

I also couldn't find anywhere where the `parse_content: true/false` boolean was used, so I removed it from the modifiers that still had it.