### PR TITLE
Add _List All_ links to top of sidebar categories on Reference page

### DIFF
--- a/resources/views/partials/side-nav.antlers.html
+++ b/resources/views/partials/side-nav.antlers.html
@@ -29,7 +29,7 @@
                             {{ /children }}
                         {{ /if }}
                         {{ if section == "reference" }}
-                            <li class="{{ permalink === current_url ?= 'active' }}" {{ if permalink === current_url}}x-effect="open = '{{ collection:title }}'"{{ /if }}>
+                            <li class="{{ permalink === current_url ?= 'active' }}" {{ if permalink === current_url }}x-effect="open = '{{ collection:title }}'"{{ /if }}>
                                 <a href="{{ url }}" class="hover:text-pink">
                                     List All {{ title }}
                                 </a>

--- a/resources/views/partials/side-nav.antlers.html
+++ b/resources/views/partials/side-nav.antlers.html
@@ -29,6 +29,12 @@
                             {{ /children }}
                         {{ /if }}
                         {{ if section == "reference" }}
+                            <li class="{{ permalink === current_url ?= 'active' }}" {{ if permalink === current_url}}x-effect="open = '{{ collection:title }}'"{{ /if }}>
+                                <a href="{{ url }}" class="hover:text-pink">
+                                    List All {{ title }}
+                                </a>
+                            </li>
+
                             {{ collection :from="slug" }}
                                 <li class="{{ permalink === current_url ?= 'active' }}" {{ if permalink === current_url }}x-effect="open = '{{ collection:title }}'"{{ /if }}>
                                     <a href="{{ url }}" class="hover:text-pink">

--- a/resources/views/partials/side-nav.antlers.html
+++ b/resources/views/partials/side-nav.antlers.html
@@ -31,7 +31,7 @@
                         {{ if section == "reference" }}
                             <li class="{{ permalink === current_url ?= 'active' }}" {{ if permalink === current_url }}x-effect="open = '{{ collection:title }}'"{{ /if }}>
                                 <a href="{{ url }}" class="hover:text-pink">
-                                    List All {{ title }}
+                                    All {{ title }}
                                 </a>
                             </li>
 


### PR DESCRIPTION
Just copied the HTML from the loop below. 
Adds a _List All Fieldtypes_, _List All Modifiers_, etc as the first item when the dropdown is open. 

Quick way to get to a nice overview of all available functions, grouped by type.

Closes #718