### PR TITLE
Fix the title of the compact modifier.

### DIFF
--- a/content/collections/modifiers/compact.md
+++ b/content/collections/modifiers/compact.md
@@ -4,9 +4,9 @@ blueprint: modifiers
 modifier_types:
   - array
   - utility
-title: As
+title: Compact
 ---
-Converts a comma-delimited list of variable names into an array that can be used anywhere arrays are accepted.
+Converts a comma-delimited list of variable names into an array that can be used anywhere. Arrays are accepted.
 
 It allows colon delimited syntax to target nested variables.
 


### PR DESCRIPTION
The compact modifier has the title "As" which leads to two entries of "As" in the left navigation:

![2022-02-10_10-06-09](https://user-images.githubusercontent.com/363363/153373990-1963f4a9-b8ae-4b2e-9fc9-0732a112c667.jpg)

Fix also some copy.
