### PR TITLE
Add `read_only` to Blueprints Document.

### DIFF
--- a/content/collections/docs/blueprints.md
+++ b/content/collections/docs/blueprints.md
@@ -261,3 +261,11 @@ listable: hidden
 ```
 
 This will hide the field from entry listings by default, but still allows a user to toggle visibility using the column selector, and save those column preferences for his/her preferred workflow.
+
+
+## Read-only / Disabled Fields
+To display a read-only (or disabled) field in a blueprint add the `read_only` parameter to the fields yaml config.
+
+```yaml
+read_only: true
+```


### PR DESCRIPTION
Noticed that `read_only` is not referenced anywhere; might be more appropriate here [https://statamic.dev/fields#common-settings](https://statamic.dev/fields#common-settings) but thought it might just be better to bury it away a bit.

Ideally would be good if there was a toggle for this in the backend.