### PR TITLE
Update supportet Laravel versions in Statamic 3.3

### DIFF
--- a/content/collections/docs/laravel.md
+++ b/content/collections/docs/laravel.md
@@ -18,7 +18,7 @@ There are many reasons why you might want to install Statamic into an existing L
 
 ## Supported Versions of Laravel
 
-**Laravel 6, Laravel 7, and Laravel 8 are all currently supported.** It feels like this section needs more than one sentence but it really doesn't. That first one said all that needs saying.
+**Laravel 8 and Laravel 9 are all currently supported.** It feels like this section needs more than one sentence but it really doesn't. That first one said all that needs saying.
 
 ## Install Statamic
 


### PR DESCRIPTION
The documentation is outdated with the release of Statamic 3.3. As mentioned [here](https://statamic.com/blog/statamic-3.3) the support for Laravel 7 is dropped.