### PR TITLE
Bumping the PHP requirements

### DIFF
--- a/content/collections/docs/requirements.md
+++ b/content/collections/docs/requirements.md
@@ -9,7 +9,7 @@ blueprint: page
 
 To run Statamic 3 you'll need a server meeting the following requirements. These are all pretty standard in most modern hosting platforms.
 
-- PHP `>= 7.2.5`
+- PHP `>= 7.4.x`
 - BCMath PHP Extension
 - Ctype PHP Extension
 - Exif PHP Extension


### PR DESCRIPTION
As per [the release blog](https://statamic.com/blog/statamic-3.3) the minimum php version is 7.4

Although laravel 8 is supported, which [supports php 7.3 or php 8](https://github.com/laravel/framework/blob/8.x/composer.json#L18), I changed it to 7.4 in the docs.
