### PR TITLE
Changes segment_2 to username for user tag.

### DIFF
--- a/content/collections/tags/user-profile.md
+++ b/content/collections/tags/user-profile.md
@@ -81,7 +81,7 @@ Route::statamic('users/{username}', 'users.show');
 Then when visiting `/users/chuck`, for example, you could display Chuck's details like this:
 
 ```
-{{ user:profile field="username" :value="segment_2" }}
+{{ user:profile field="username" :value="username" }}
   {{ first_name }} {{ last_name }}
 {{ /user:profile }}
 ```


### PR DESCRIPTION
Though segment_2 works it's confusing unless you knew what [segment_x](https://statamic.dev/variables/segment_x) is ahead of time.

So, perhaps using `:value="username"` is more intuitive, otherwise there perhaps should be a quick explanation of `segment_x` and a link there.

I don't know what the cons to using `username` here would be unless a developer chose a conflicting variable name in the route.
