### PR TITLE
Mention additional Static Caching settings in Multi-Site docs

### DIFF
--- a/content/collections/docs/multi-site.md
+++ b/content/collections/docs/multi-site.md
@@ -210,3 +210,8 @@ Indicate the current language of the site by setting the `lang` attribute on you
 <html lang="{{ site:short_locale }}">
 ```
 
+:::
+
+## Static Caching
+
+If your multi-site should use static caching, you will also need to add additional config parameters and different server rewrite rules. Please refer to the related section of the [static caching documentation](/static-caching#multisite) for the correct settings.


### PR DESCRIPTION
On multiple occasions people on Discord (as well as I myself at one point) got confused about using Static Caching on a Multi-Site. The correct settings are only explained in the docs for Static Caching, not in the ones for Multi-Site, which is why some people miss that vital information when creating a Multi-Site.

So I added a quick link to the bottom of the Multi-Site docs to avoid this confusion in the future.