### PR TITLE
Suggest better redis cache prefix configuration

### DIFF
--- a/content/collections/tips/zero-downtime-deployments.md
+++ b/content/collections/tips/zero-downtime-deployments.md
@@ -71,7 +71,3 @@ To avoid sharing a Redis cache between your deployment releases, we recommend se
     ],
 ],
 ```
-
-:::tip
-Run `php artisan cache:clear` after each deployment to ensure you don't bloat your Redis cache with old release data over time.
-:::


### PR DESCRIPTION
We had a customer report CSRF errors when prefixing in config/cache.php. This can happen when you use both redis based cache and redis based session. The envoyer release directory would be applied to each session (which contains the CSRF token), but it should only be applied to the cache.