### PR TITLE
Remove colon property access in front of bracket access

### DIFF
--- a/content/collections/docs/new-antlers-parser.md
+++ b/content/collections/docs/new-antlers-parser.md
@@ -336,7 +336,7 @@ Docsylvania
 You can combine literal and dynamic keys and get real fancy if you need to.
 
 ```
-{{ complex_data:[3][field]['title'] }}
+{{ complex_data[3][field]['title'] }}
 ```
 
 ### Disambiguation 🆕 {#disambiguating-variables}


### PR DESCRIPTION
Chatted with @JohnathonKoster about that. He mentioned that the syntax might work but it is not recommended to use.