### PR TITLE
Improve glide docs

### DIFF
--- a/content/collections/docs/image-manipulation.md
+++ b/content/collections/docs/image-manipulation.md
@@ -1,0 +1,164 @@
+---
+id: 245068a1-1900-4774-a3ba-29192dc9acff
+blueprint: page
+title: 'Image Manipulation (Glide)'
+intro: Statamic uses [Glide](https://glide.thephpleague.com) to manipulate images – from resizing and cropping to adjustments (like sharpness and contrast) and image effects (like pixelate and sepia).
+---
+## Route
+The route controls where your Glide images will be served.
+
+```php
+'image_manipulation' => [
+    'route' => 'img'
+]
+```
+
+By default your Glide images will be served from `'/img/...'` but you are free to change that. Perhaps if you intend to have some actual images stored in the `img` directory.
+
+:::tip
+This route setting may become irrelevant when using customizing [caching options](#caching) explained further down this page.
+:::
+
+## Presets
+
+Glide Presets are pre-configured manipulations that will be automatically generated when new image assets are uploaded. These presets are managed in `config/statamic/assets.php` as an array that holds a list of named presets and their desired parameters.
+
+```php
+'image_manipulation' => [
+    'presets' => [
+        'thumbnail' => [ 'w' => 300, 'h' => 300, 'q' => 75],
+        'hero'      => [ 'w' => 1440 'h' => 600, 'q' => 90 ],
+    ],
+],
+```
+
+All standard Glide API parameters are available for use in presets. (Not the tag aliases like `width`. You'll need to use `w`.)
+
+Each named preset can be referenced with the `preset` parameter on the [Glide tag][glide-tag] and since all transformations and manipulations are performed at time of upload, there shouldn't be any additional overhead on the initial request.
+
+**Example:**
+
+```
+{{ glide:thumbnail preset="thumbnail" }}
+<!-- width: 300px, height: 300px, quality: 75% -->
+
+{{ glide:hero_image preset="hero" }}
+<!-- width: 1440px, height: 600px, quality: 90% -->
+```
+
+## Caching
+
+Out of the box, Glide will "just work". However you may want to adjust its caching methods for better performance.
+
+In the context of Glide, the "source" is the filesystem where the original images are kept, and the "cache" is the filesystem where it saves the manipulated images.
+
+### Default (Dynamic)
+
+The default behavior is for the cache to be "disabled" or "dynamic".
+
+```php
+'image_manipulation' => [
+    'route' => 'img',
+    'cache' => false,
+]
+```
+
+From a user's point of view, the "cache" is disabled, however technically it's just located at `storage/statamic/glide`.
+
+The [Glide tag][glide-tag] will output URLs to the configured Glide [route](#route). When one of these URLs are visited, Statamic will use Glide to perform the transformation.
+
+:::tip
+When using this method, since the Glide tag only needs to generate URLs, the load time of the page will be faster, but the initial load time of each image request will be slower.
+:::
+
+### Custom Path (Static)
+
+The next level of caching would be to specify a custom, publicly accessible location for the images to be generated.
+
+``` php
+'image_manipulation' => [
+    'route' => 'img',
+    'cache' => true,
+    'cache_path' => public_path('img'),
+]
+```
+
+When using this setting, the [Glide tag][glide-tag] will _actually generate_ the images instead of just outputting a URL.
+
+Since the images are generated to a publicly accessible location, the next time a user visits the image URL, the static image would be served directly by the server, and would not need to be touched by PHP or Statamic.
+
+:::tip
+When using this method, since the Glide tag has to generate the images, the initial load time of the page will be slower.
+:::
+
+### Custom Disk (CDN)
+
+You may choose to save your cached Glide images to somewhere CDN based, like Amazon S3 or DigitalOcean Spaces. Instead of specifying `true` as mentioned above, you can point to a filesystem disk.
+
+```php
+'image_manipulation' => [
+    'cache' => 'glide',
+],
+```
+
+```php
+// config/filesystems.php  [tl! **]
+
+'disks' => [  // [tl! **]
+    'glide' => [  // [tl! **]
+        'driver' => 's3',  // [tl! **]
+        'key' => env('AWS_ACCESS_KEY_ID'),
+        'secret' => env('AWS_SECRET_ACCESS_KEY'),
+        'region' => env('AWS_DEFAULT_REGION'),
+        'bucket' => env('AWS_BUCKET'),
+        'url' => env('AWS_URL'),  // [tl! **]
+        'endpoint' => env('AWS_ENDPOINT'),
+        'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+        'visibility' => 'public',  // [tl! **]
+    ],
+]
+```
+
+:::tip
+Make sure that the `visibility` is `public` and that the `url` points to the correct location.
+:::
+
+:::warning
+Don't use the same disk or bucket as your source images. If you were you to clear your Glide cache (e.g. when using the `glide:clear` command) the whole disk will be emptied.
+:::
+
+## Path Cache Store
+
+Before Glide tries to generate an image, it will look into the filesystem to determine whether the image has already been generated. This will prevent the need for the image to be needlessly re-generated.
+
+However, when using the [Custom Disk CDN](#custom-disk-cdn) caching option with a service like Amazon S3 for example, Glide will need to make an API call just to be able to check if a file exists. This would cause a slowdown.
+
+To alleviate this problem, Statamic will keep track of whether the images have already been generated in its own separate cache.
+
+This cache is separate from your application cache. Running `php artisan cache:clear` will **not** clear this Glide cache. This allows the Glide cache to persist through deployments or other scenarios where you might clear your application cache. It will be cleared when running `php please glide:clear`.
+
+By default, this cache will be located in your filesystem with the storage directory.
+
+If you would like to customize it, you can create a new store named `glide` in your `config/cache.php` configuration file. For example:
+
+```php
+'stores' => [
+    'file' => [
+        'driver' => 'redis',
+        'connection' => 'glide',
+    ],
+]
+```
+
+## Clearing the cache
+
+You may manually clear the Glide cache by running the following command:
+
+```
+php artisan glide:clear
+```
+
+This will **delete all the files** within your Glide cache filesystem location, as well as clearing the [path cache](#path-cache-store).
+
+
+[glide-tag]: /tags/glide

--- a/content/collections/tags/glide.md
+++ b/content/collections/tags/glide.md
@@ -124,6 +124,45 @@ filters:
     type: string
     description: >
       Applies a filter effect to the image. Accepts `greyscale` or `sepia`.
+other:
+  -
+    name: preset
+    type: string
+    description: >
+      Applies a [preset manipulation](/image-manipulation#presets) as defined in the config.
+  -
+    name: mark
+    type: string
+    description: >
+      The source of a [watermark](#watermarks).
+  -
+    name: markw
+    type: string
+    description: The width of the watermark.
+  -
+    name: markh
+    type: string
+    description: The height of the watermark.
+  -
+    name: markfit
+    type: string
+    description: The fit of the watermark. [See Glide docs](https://glide.thephpleague.com/2.0/api/watermarks/#fit-markfit)
+  -
+    name: markx
+    type: string
+    description: How far the watermark is away from the left and right edges.
+  -
+    name: marky
+    type: string
+    description: How far the watermark is away from the top and bottom edges.
+  -
+    name: markpad
+    type: string
+    description: How far the watermark is away from all edges. A shortcut for using markx and marky.
+  -
+    name: markpos
+    type: string
+    description: Sets where the watermark is positioned. Accepts `top-left`, `top`, `top-right`, `left`, `center`, `right`, `bottom-left`, `bottom`, `bottom-right`. Default is `bottom-right`.
 variables:
   -
     name: url
@@ -137,21 +176,55 @@ variables:
     name: height
     type: integer
     description: The height of the resized image.
+  -
+    name: asset data
+    type: mixed
+    description: If your source was an asset, you will also have all of its fields available. e.g. `alt`
 id: b70a3d9a-6605-446e-b278-de99ba561fe0
 ---
-## Overview
+## Setting up Glide
+Glide is ready to go out of the box with no setup required. However, you may customize its behavior. You can read about it on the [image manipulation](/image-manipulation) page.
 
-The Glide tag leverages the fantastic [Glide](http://glide.thephpleague.com/) PHP library to give you on-demand image manipulation, similar to cloud image processing services like [Imgix](https://www.imgix.com/) and [Cloudinary](https://cloudinary.com/).
+## Basic Usage
 
-
-Manipulate images by passing a variable or an explicit URL and adding the desired [parameters](#parameters) like `height`, `crop`, or `quality`.
+Manipulate images by passing an image [source](#sources) and adding the desired [parameters](#parameters) like `height`, `crop`, or `quality`.
 
 ```
-// Variable
-<img src="{{ glide:hero_image width="1280" height="800" }}">
+{{ glide src="image.jpg" width="1280" height="800" }}
+```
+```output
+/img/image.jpg?w=1280&h=800
+```
 
-// URL
-<img src="{{ glide src="/img/heroes/slime.jpg" width="1280" height="800" }}">
+The Glide tag outputs a URL of the transformed image, so you'll likely want to use it as the `src` for an `<img />` HTML tag.
+
+```
+<img src="{{ glide ... }}" />
+```
+
+## Sources
+
+There are a number of options when it comes to what you can use as an image source.
+
+### Asset
+You can pass along an asset object by using an asset field by reference:
+
+```
+{{ glide :src="asset_field" w="100" }} // /img/asset/6f75d8as?w=100
+```
+
+### Relative path/URL
+You can pass a string of a path located within your `public` directory.
+
+```
+{{ glide src="image.jpg" w="100" }} // img/image.jpg?w=100
+```
+
+### External URL
+You can pass a string of a URL on another site.
+
+```
+{{ glide src="http://anothersite.com/image.jpg" w="100" }} // /img/http/6f75d8as?w=100
 ```
 
 
@@ -160,35 +233,67 @@ Manipulate images by passing a variable or an explicit URL and adding the desire
 If you use the tag as a pair, you'll have access to `url`, `height`, and `width` variables inside to do with as you wish.
 
 ```
-{{ glide:image width="600" }}
+{{ glide src="image.jpg" width="600" }}
     <img src="{{ url }}" width="{{ width }}" height="{{ height }}">
-{{ /glide:image }}
+{{ /glide }}
 ```
 
-## Presets
-
-Glide Presets are pre-configured manipulations that will be automatically generated when new image assets are uploaded. These presets are managed in `config/statamic/assets.php` as an array that holds a list of named presets and their desired parameters.
-
-```php
-'presets' => [
-  'thumbnail' => [ 'w' => 300, 'h' => 300, 'q' => 75],
-  'hero'      => [ 'w' => 1440 'h' => 600, 'q' => 90 ],
-],
-```
-
-All [parameters](#parameters) are available for use in presets.
-
-Each named preset can be referenced with the `preset` tag parameter and since all transformations and manipulations are performed at time of upload, there shouldn't be any additional overhead on the initial request.
-
-**Example:**
+You may also use the tag pair to loop over multiple sources. For example, you may provide it with an `assets` field.
 
 ```
-{{ glide:thumbnail preset="thumbnail" }}
-<!-- width: 300px, height: 300px, quality: 75% -->
-
-{{ glide:hero_image preset="hero" }}
-<!-- width: 1440px, height: 600px, quality: 90% -->
+{{ glide :src="multiple_assets" width="600" }}
+   ...
+{{ /glide }}
 ```
+
+:::tip
+The tag pair is also available as `{{ glide:generate }}`. You may need to use this version if you're using [Blade](#usage-in-blade).
+:::
+
+:::tip
+Normally, the Glide tag only generates a URL. The image itself is generated when the URL is visited. When using the tag pair, your Glide images will be generated when the page is rendered. This will result in an initial longer load time.
+:::
+
+
+## Shorthand Tag
+
+Rather than using the `src` parameter, you may choose to use a variable name as the second part of the tag.
+
+```
+{{ glide:my_var w="100" }}
+```
+
+You may also use the shorthand as a tag pair:
+
+```
+{{ glide:my_var }} ... {{ /glide:my_var }}
+```
+
+
+## Watermarks
+
+You may use Glide's [watermarking feature](https://glide.thephpleague.com/2.0/api/watermarks/) by passing in a [source](#source) to the `mark` parameter, and then manipulate it using the various watermark parameters (`markw`, `markh`, `markfit`, etc).
+
+```
+{{ glide src="image.jpg" mark="watermark.jpg" markw="30" }}
+```
+
+:::tip
+You don't need to worry about setting up a watermark filesystem yourself. Statamic will take care of that automatically based on the source you provide.
+:::
+
+
+## Usage in Blade
+
+To use the Glide tag within Blade, you should use the `generate` tag, which follows the same rules as the [tag pair](#tag-pair).
+
+```blade
+@foreach (Statamic::tag('glide:generate')->src($source)->width(100) as $image)
+  <img src="{{ $image['url'] }} width="{{ $image['width'] }}" />
+@endforeach
+```
+
+You should use a `@foreach` loop even if you are only providing a single source.
 
 ## Focal Point Cropping
 
@@ -240,21 +345,3 @@ images:
 <img src="/img/image.jpg?w=600" />
 <img src="/assets/image.svg" />
 ```
-
-## Serving Cached Images Directly
-
-The default Glide tag behavior is to simply output a URL. When a URL is visited, Glide analyzes the URL and manipulates the image. However, if there are a lot of manipulations on any given page request, the total execution time can soon start to add up.
-
-You can avoid these slowdowns by generating static images. Your server will load images directly instead of handing the work over to the Glide process each time. You can enable this behavior in your assets config file.
-
-``` php
-// config/statamic/assets.php
-
-'cache' => true,
-```
-
-## Using Glide with Locales
-
-When using Glide with multiple locales, the generated image path will include the proper `site_root` as dictated by the locale, but the actual asset will be stored wherever you have set the `cache_path`.
-
-To serve these assets when on a localized version, you'll need to create a symlink from your `/$locale/cache_path` to `cache_path`.

--- a/content/trees/collections/docs.yaml
+++ b/content/trees/collections/docs.yaml
@@ -148,6 +148,8 @@ tree:
   -
     entry: fc564ddf-80c1-4d87-8675-4a41f13c7774
   -
+    entry: 245068a1-1900-4774-a3ba-29192dc9acff
+  -
     entry: c095fb87-4c02-462c-9e6f-dfe0b6889248
   -
     entry: a77eb282-e050-4288-b83d-789840e245fd

--- a/content/trees/navigation/docs.yaml
+++ b/content/trees/navigation/docs.yaml
@@ -136,6 +136,10 @@ tree:
         id: 05a7b681-86e7-4ac7-883c-27bc03d79f38
         entry: fc564ddf-80c1-4d87-8675-4a41f13c7774
       -
+        id: 08e937a0-bb37-11ec-bf84-0800200c9a66
+        entry: 245068a1-1900-4774-a3ba-29192dc9acff
+        title: Image Manipulation
+      -
         id: 68c69f7b-3560-40e6-a4ba-abc98d7ce4af
         entry: 131259a5-2072-49d8-9ea4-2099e0338e2f
       -

--- a/resources/blueprints/collections/tags/tag-glide.yaml
+++ b/resources/blueprints/collections/tags/tag-glide.yaml
@@ -99,6 +99,26 @@ sections:
               field:
                 type: markdown
       -
+        handle: other
+        field:
+          type: grid
+          mode: stacked
+          fields:
+            -
+              handle: name
+              field:
+                type: text
+                width: 33
+            -
+              handle: type
+              field:
+                type: text
+                width: 33
+            -
+              handle: description
+              field:
+                type: markdown
+      -
         handle: template
         field:
           display: Template

--- a/resources/views/tags/glide.antlers.html
+++ b/resources/views/tags/glide.antlers.html
@@ -23,8 +23,12 @@
     <h3>Filters and Effects</h3>
     {{ partial:details :details="filters" }}
 
+    <h3>Other</h3>
+    {{ partial:details :details="other" }}
+
     {{ if variables }}
         <h2 id="variables">Variables</h2>
+        <p>These variables are only available within the <a href="#tag-pair">tag pair</a>.</p>
         {{ partial:variables }}
     {{ /if }}
 


### PR DESCRIPTION
This makes a dedicated docs page for image manipulation named `Image Manipulation (Glide)` so it should be found when you search for Glide.

The glide tag page is now more focused on tag specific stuff.

More general configuration stuff is on the new image manipulation page.

This adds docs about caching and watermarking being introduced in https://github.com/statamic/cms/pull/5725

It adds a section about using the Glide tag in Blade views. Closes #790