### PR TITLE
Accessing other field values from custom fieldtype

### DIFF
--- a/content/collections/extending-docs/fieldtypes.md
+++ b/content/collections/extending-docs/fieldtypes.md
@@ -296,6 +296,20 @@ public function augment($value)
 
 [Read more about augmentation](/extending/augmentation)
 
+## Accessing Other Fields
+
+If you find yourself needing to access other form field values, configs, etc., you can reach into the publish form store from within your Vue component: 
+
+```js
+inject: ['storeName'],
+
+computed: {
+    formValues() {
+        return this.$store.state.publish[this.storeName].values;
+    },
+},
+```
+
 ## Updating from v2
 
 In Statamic v2 we pass a `data` prop that can be directly modified. You might be see something like this:


### PR DESCRIPTION
I see a few problems with using these `values` though...

1. Hidden fields (using conditions) will still show up in this `values` payload, which may lead to unexpected consequences.

2. Bard values are JSON encoded, which adds unnecessary complexity for people wanting to parse through bard values.

Maybe we could `provide()` a normalized values payload (using some of the logic from our [Omitter](https://github.com/statamic/cms/blob/3.3/resources/js/components/field-conditions/Omitter.js) class to solve the above problems), and allow the user to inject those normalized values into their components via `inject: ['formValues']`?

Or maybe we should just apply these normalizations to the `values` in the store?

Thoughts @jasonvarga?