### PR TITLE
add valet for windows port as an option

### DIFF
--- a/content/collections/docs/requirements.md
+++ b/content/collections/docs/requirements.md
@@ -39,12 +39,15 @@ You can even share your sites publicly using local tunnels. We use it ourselves 
 
 ### Windows: WAMP
 
-[Laragon][laragon] and [WAMP][wamp] are both good choice for those of the Windows persuasion. You may also want to checkout [Laravel Sail](https://laravel.com/docs/8.x/sail), which works well with Statamic.
+[Laragon][laragon] and [WAMP][wamp] are both good choice for those of the Windows persuasion. You may also want to checkout [Laravel Sail](https://laravel.com/docs/8.x/sail), which works well with Statamic or the [Valet for Windows port][valet-windows].
+
+
 
 [do]: https://m.do.co/c/6469827e2269
 [vultr]: https://www.vultr.com/?ref=7337126
 [hosts]: https://github.com/statamic/hosts
 [homestead]: https://laravel.com/docs/homestead
 [valet]: https://laravel.com/docs/valet
+[valet-windows]: https://github.com/cretueusebiu/valet-windows
 [wamp]: http://www.wampserver.com/
 [laragon]:https://laragon.org/


### PR DESCRIPTION
The docs don't mention there's a Valet port for Windows. This change fixes that.