### PR TITLE
Improve Glide cache example

### DIFF
--- a/content/collections/docs/image-manipulation.md
+++ b/content/collections/docs/image-manipulation.md
@@ -148,11 +148,25 @@ If you would like to customize it, you can create a new store named `glide` in y
 
 ```php
 'stores' => [
-    'file' => [
+    'glide' => [
         'driver' => 'redis',
         'connection' => 'glide',
     ],
 ]
+```
+
+In this example, you would also need to create a Redis database named `glide` in your `config/database.php` configuration file:
+
+```php
+'redis' => [
+    'glide' => [
+        'url' => env('REDIS_URL'),
+        'host' => env('REDIS_HOST', '127.0.0.1'),
+        'password' => env('REDIS_PASSWORD'),
+        'port' => env('REDIS_PORT', '6379'),
+        'database' => env('REDIS_GLIDE_DB', '2'),
+    ],
+],
 ```
 
 ## Clearing the cache


### PR DESCRIPTION
1) There's a typo in the example: It says "a new store named `glide`", but the store in the code is called `file`.
`glide` is the correct one.

2) I think the example should also show how to define the required Redis database/connection named `glide`.