### PR TITLE
Remove documented flysystem-aws-s3 adapter version

### DIFF
--- a/content/collections/tips/digital-ocean-spaces-for-asset-container.md
+++ b/content/collections/tips/digital-ocean-spaces-for-asset-container.md
@@ -16,7 +16,7 @@ Since Digital Ocean Spaces is compatible with the Amazon S3 API, you can use the
 First, install the AWS Flysystem adapter:
 
 ``` shell
-composer require "league/flysystem-aws-s3-v3 ~1.0"
+composer require league/flysystem-aws-s3-v3
 ```
 
 ## Configure a filesystem


### PR DESCRIPTION
Let Statamic constrain version, since we support both 1.x and 3.x right now (due to us supporting both Laravel 8 and 9).