### PR TITLE
Conditional fields and Revealer fieldtype clarifications

### DIFF
--- a/content/collections/docs/conditional-fields.md
+++ b/content/collections/docs/conditional-fields.md
@@ -264,3 +264,29 @@ Statamic.$conditions.add('...', ({ root, store, storeName }) => {
     //
 });
 ```
+
+## Validation
+
+If you wish to conditionally apply validation to conditionally shown fields, we recommend using the `sometimes` [Laravel validation rule](https://laravel.com/docs/validation#validating-when-present).
+
+```
+-
+  handle: online_event
+  field:
+    type: toggle
+-
+  handle: venue
+  field:
+    type: text
+    if:
+      online_event: false
+    validate:
+      - sometimes
+      - required
+```
+
+The above example will only _sometimes_ apply the `required` rule to the `venue` field; Only when it exists in the submitted form data (see notes on [data flow](#data-flow) above).
+
+:::tip
+For more advanced conditional validation, take a look at Laravel's `required_if`, `required_with`, etc. [validation rules](https://laravel.com/docs/validation#rule-required-if).
+:::

--- a/content/collections/docs/conditional-fields.md
+++ b/content/collections/docs/conditional-fields.md
@@ -7,7 +7,7 @@ blueprint: page
 ---
 ## Overview
 
-Field conditions are set on individual field settings in [blueprints](/blueprints). For example, you could create a `meta_description` field that is only shown when the `content` field is longer than 140 characters.
+Field conditions are set on individual field settings in [blueprints](/blueprints). For example, you could create a `meta_description` field that is only shown and submitted when the `content` field is longer than 140 characters.
 
 <figure>
     <img src="/img/field-conditions.png" alt="Statamic conditional field rule builder">
@@ -15,6 +15,14 @@ Field conditions are set on individual field settings in [blueprints](/blueprint
 </figure>
 
 You may specify various rules for showing a field under either the `if` / `show_when` keys, or hiding a field under the `unless` / `hide_when` keys.
+
+### Data Flow
+
+Only visible fields are submitted with your form data by default. This allows you to control data flow, and [conditionally apply validation](#validation) to visible fields when needed.
+
+:::tip
+If you want to cosmetically hide a larger set of fields to get them out of the user's way, you can use the [Revealer](/fieldtypes/revealer) fieldtype to hide them until the user needs them without disrupting data flow on form submission.
+:::
 
 ## Boolean
 

--- a/content/collections/docs/validation.md
+++ b/content/collections/docs/validation.md
@@ -65,7 +65,6 @@ However, if you want to use validation rules that target other fields, and the t
 
 This would make sure that the `price` field is only required if the `purchasable` toggle is true within that same set. Without `{this}`, it would be checking for a `purchasable` field at the top level of your form.
 
-<!--
 :::best-practice
 Rather than reaching for `{this}`, you can consider using conditional fields along with the `sometimes|required` rules.
 
@@ -84,7 +83,6 @@ Rather than reaching for `{this}`, you can consider using conditional fields alo
           - required
 ```
 :::
--->
 
 
 ## Available Rules

--- a/content/collections/fieldtypes/revealer.md
+++ b/content/collections/fieldtypes/revealer.md
@@ -1,7 +1,7 @@
 ---
 title: Revealer
 description: A button that reveals conditional fields like magic.
-intro: The revealer is a simple button that reveals conditional fields without saving any additional data.
+intro: The revealer is a simple button that reveals conditional fields without saving boolean button data.
 id: 54066363-7dec-431c-86c6-7e9353380ef5
 screenshot: fieldtypes/screenshots/revealer.gif
 stage: 3
@@ -15,11 +15,19 @@ options:
     type: string
     description: Instructional text that will appear as a tooltip on the button.
 ---
-This fieldtype is intended to be used with [conditional field rules](/conditional-fields). If you have some fields that should only sometimes show, throw a Revealer field in there and those fields may be shown once the button is clicked.
+
+If you have some fields that you wish to hide until the user is ready to reveal them, throw a Revealer field in there and those fields may be shown once the button is clicked.
+
+This fieldtype is intended to be used with our [conditional field rules](/conditional-fields), but unlike regular conditional fields, it will not [disrupt data flow](/conditional-fields#data-flow) on fields hidden by a Revealer.
 
 The example image above uses the following field configuration:
 
 ``` yaml
+  -
+    handle: behold
+    field:
+      type: revealer
+      display: 'Behold!'
   -
     handle: revealed
     field:
@@ -27,13 +35,6 @@ The example image above uses the following field configuration:
       display: 'I am revealed!'
       if:
         behold: 'equals true'
-  -
-    handle: behold
-    field:
-      type: revealer
-      display: 'Behold!'
 ```
 
-Regardless of whether the button was clicked or not, no data will be saved.
-
-
+Regardless of whether the button was clicked or not, no boolean data will be saved for the `behold` Revealer button itself.


### PR DESCRIPTION
- [x] Clarify differences between revealer fieldtype and conditional field data flow.
- [x] Add documentation for `sometimes`, `required_if`, etc. conditional field validation helper rules.
- [x] Uncomment 'best practice' tip @jasonvarga left, now that we properly support this stuff since 3.3 👍