### PR TITLE
Use `trans_choice` in `trans_choice` examples.

### DIFF
--- a/content/collections/modifiers/trans.md
+++ b/content/collections/modifiers/trans.md
@@ -44,8 +44,8 @@ Parameter replacements are only supported in the [tag version](/tags/trans).
 To pluralize, use the `trans_choice` modifier with the count as the parameter. You can use a number or a variable.
 
 ```
-{{ "foo.apples" | trans:2 }}
-{{ "foo.apples" | trans:this_many }}
+{{ "foo.apples" | trans_choice:2 }}
+{{ "foo.apples" | trans_choice:this_many }}
 ```
 
 ```html


### PR DESCRIPTION
`trans` was used in `trans_choice` examples.