### PR TITLE
Adding details about Navigation `next` and `prev` to the new parser page

### DIFF
--- a/content/collections/docs/new-antlers-parser.md
+++ b/content/collections/docs/new-antlers-parser.md
@@ -1338,7 +1338,7 @@ The following two examples are functionally equivalent, but each uses a differen
 <a href="{{ $register }}">Register for a new account</a>
 ```
 
-``` antlers
+```antlers
 <a href="{{$ route('account.register') $}}">Register for a new account</a>
 ```
 
@@ -1350,4 +1350,14 @@ You can also change your view's file extension from `.antlers.html` to `.antlers
 <?php
   echo 'Keep it simple, please';
 ?>
+```
+
+### Navigation
+
+You can now use `next` and `prev` to access the title and url of the previous and next entries in the navigation array. This is automagically attacted at runtime -- boom shakalaka!
+
+```antlers
+Prev: {{ prev.url }} {{ prev.title }}<br />
+Current: {{ url }} {{ title }}<br />
+Next: {{ next.url }} {{ next.title }} <br />
 ```


### PR DESCRIPTION
Added details about Navigation's `next` and `prev` to `new-parser` page.

I learned about `next` and `prev` from @JohnathonKoster in the [Statamic Discord](https://discord.com/channels/489818810157891584/489819906540568593/979845502680055908). I think it's a useful thing in the docs - to save futureDavid (or anyone else) time. 

I'm not sure on the best location for this in the `new-parse` page, so I added it to the end. Totally open to suggestions to improve location and/or markup and/or copy. 

(Prior PR = https://github.com/statamic/docs/pull/835)