### PR TITLE
Fixes collection tag typo on chunk modifier page

### DIFF
--- a/content/collections/modifiers/chunk.md
+++ b/content/collections/modifiers/chunk.md
@@ -21,7 +21,7 @@ Break arrays or collections into smaller (wait for it) chunks of any given size.
     {{ /chunk }}
   </div>
   {{ /posts }}
-{{ /collection:newsroom }}
+{{ /collection:news }}
 ```
 
 ```html


### PR DESCRIPTION
Fixes the closing `collection` tag typo from `{{ /collection:newsroom }}` to `{{ /collection:news }}`.