### PR TITLE
Update the decode modifier document to make it clearer what it does

### DIFF
--- a/content/collections/modifiers/decode.md
+++ b/content/collections/modifiers/decode.md
@@ -8,7 +8,7 @@ title: Decode
 Convert all HTML entities to their applicable characters via PHP's [html_entity_decode()][decode] function. Will convert both double and single quotes. This is the opposite of the [entities][entities] modifier.
 
 ```yaml
-string: "I'll \"eat\" the <b>bacon</b> now";
+string: "I'll &quot;eat&quot; the &lt;b&gt;bacon&lt;/b&gt; now";
 ```
 
 ```


### PR DESCRIPTION
The [current `decode` documentation](https://statamic.dev/modifiers/decode) doesn't make it very clear what the modifier does. This updates the YAML string to include HTML entities that will be decoded.