### PR TITLE
fix .external svg color on dark mode

### DIFF
--- a/resources/css/content.css
+++ b/resources/css/content.css
@@ -54,7 +54,8 @@ article, .markdown {
     a svg.external {
         @apply inline-block;
         vertical-align: text-top;
-        color: rgba(0,0,0,.6);
+        color: currentColor;
+        opacity: .6;
     }
 
     h2 > .anchor,


### PR DESCRIPTION
<img width="253" alt="Bildschirmfoto 2022-08-04 um 08 26 07" src="https://user-images.githubusercontent.com/6337411/182778141-ab9cd56d-0dfa-4408-a0fe-8a09e1876bd5.png">
