### PR TITLE
fix spelling of 'controlling'

### DIFF
--- a/content/collections/docs/assets.md
+++ b/content/collections/docs/assets.md
@@ -60,7 +60,7 @@ data:
 ```
 
 :::tip
-You should consider version controling these files if you plan to set data like alt tags and focal points. Make sure your efforts are preserved.
+You should consider version controlling these files if you plan to set data like alt tags and focal points. Make sure your efforts are preserved.
 :::
 
 ## Containers


### PR DESCRIPTION
A quick spelling fix: 
  'version controling' => 'version controlling'