### PR TITLE
fix wrong link

### DIFF
--- a/content/collections/tips/laravel-nova.md
+++ b/content/collections/tips/laravel-nova.md
@@ -12,7 +12,7 @@ updated_at: 1622821126
 We've heard users saying they'd like to manage the front-end with Statamic and the back-end with [Laravel Nova](https://nova.laravel.com/). That's fine! It's possible to run both Statamic and Nova together.
 
 :::tip
-If you'd like to manage Eloquent models within Statamic, [you're able to do that, too](/extending/publish-forms).
+If you'd like to manage Eloquent models within Statamic, [you're able to do that, too](/tips/storing-entries-in-a-database).
 :::
 
 1. Install Nova as per their documentation


### PR DESCRIPTION
I added what I believe to be a link making more sense, since `/tips/storing-entries-in-a-database` explicitly talks about how to manage Eloquent models within Statamic

If I'm mistaken here feel free to simply close this PR, just was totally confused as I followed the link.

Best
Simon