### PR TITLE
Correct relative modifier docs, include example output

### DIFF
--- a/content/collections/modifiers/relative.md
+++ b/content/collections/modifiers/relative.md
@@ -7,23 +7,25 @@ title: Relative
 ---
 Returns a date difference in a nice, human readable, string format. This modifier will add a phrase after the difference value relative to the current date and the passed in date.
 
-You can turn off the extra words "ago", "until", and so on by passing `false` as a parameter
+You can turn off the extra words "ago", "until", and so on by passing `true` as a parameter
 
 The string will be localized into your current site locale.
 
 ```yaml
-past_date: October 1 2015
-future_date: October 1 2019
+past_date: October 1 2020
+future_date: October 1 2024
 ```
 
 ```
 {{ past_date | relative }}
+{{ past_date | relative:true }}
 {{ future_date | relative }}
-{{ past_date | relative:false }}
+{{ future_date | relative:true }}
 ```
 
 ```html
-{{ test_date | relative }}
-{{ test_future_date | relative }}
-{{ test_date | relative:false }}
+2 years ago
+2 years
+1 year from now
+1 year
 ```


### PR DESCRIPTION
The relative modifiers `remove_modifiers` param should be `true` to remove the extra words, as per [the comment](https://github.com/statamic/cms/blob/5082efc80f2bf22416c79649542ee501be7a9e34/src/Modifiers/CoreModifiers.php#L1942).

However the docs actually say that you should use `false`.

This PR corrects that and also adds some actual output examples.

Related to https://github.com/statamic/cms/pull/6976