### PR TITLE
Add max_items to terms and collections docs

### DIFF
--- a/content/collections/fieldtypes/collections.md
+++ b/content/collections/fieldtypes/collections.md
@@ -5,10 +5,10 @@ description: Choose from one or more collections.
 overview: Allows you to choose one or more collections.
 options:
   -
-    name: collection
-    type: string/array
+    name: max_items
+    type: integer
     description: >
-      You can pass a single collection as a string or multiple collections as an array.
+      The maximum number of items that may be selected. Setting this to `1` will change the UI to a dropdown.
 screenshot: /fieldtypes/screenshots/collections.png
 id: 44c3da60-ef47-408e-afc4-a33026c86f5d
 ---

--- a/content/collections/fieldtypes/terms.md
+++ b/content/collections/fieldtypes/terms.md
@@ -7,6 +7,11 @@ intro: >
 screenshot: fieldtypes/screenshots/terms.png
 options:
   -
+    name: max_items
+    type: integer
+    description: >
+      The maximum number of items that may be selected. Setting this to `1` will change the UI to a dropdown.
+  -
     name: taxonomy
     type: string
     description: >


### PR DESCRIPTION
The Terms and Collections fieldtypes support `max_items` but it's missing from the docs. This PR adds them.

Also the Collections fieldtype says it has a `collection` option, which it doesn't, so that has been removed.