### PR TITLE
Fixed missing end quote on blade usage example

### DIFF
--- a/content/collections/tags/glide.md
+++ b/content/collections/tags/glide.md
@@ -293,7 +293,7 @@ To use the Glide tag within Blade, you should use the `generate` tag, which foll
 
 ```blade
 @foreach (Statamic::tag('glide:generate')->src($source)->width(100) as $image)
-  <img src="{{ $image['url'] }} width="{{ $image['width'] }}" />
+  <img src="{{ $image['url'] }}" width="{{ $image['width'] }}" />
 @endforeach
 ```
 


### PR DESCRIPTION
There was a missing end quote on the img src attribute. Ashamed to say I missed it for a good 10 minutes haha.