### PR TITLE
Remove undefined methods

### DIFF
--- a/content/collections/repositories/term-repository.md
+++ b/content/collections/repositories/term-repository.md
@@ -24,8 +24,6 @@ use Statamic\Facades\Term;
 | `find($id)` | Get Term by `id` |
 | `findByUri($uri)` | Get Term by `uri` |
 | `query()` | Query Builder |
-| `whereTaxonomy($handle)` | Get Terms in a `Taxonomy` |
-| `whereInTaxonomy([$handles])` | Get all Terms in an array of `Taxonomys` |
 | `make()` | Makes a new `Term` instance |
 
 ## Querying


### PR DESCRIPTION
Call to undefined method Statamic\Stache\Query\TermQueryBuilder::whereTaxonomy() Call to undefined method Statamic\Stache\Query\TermQueryBuilder::whereInTaxonomy()