### PR TITLE
get_content shorthand only accepts IDs, not URLs.

### DIFF
--- a/content/collections/tags/get_content.md
+++ b/content/collections/tags/get_content.md
@@ -49,12 +49,8 @@ You may also use a shorthand syntax, where the second tag argument refers to a v
 
 ```
 ---
-related_by_uri: /about
 related_by_id: 123-321-abc-defg123
 ---
-{{ get_content:related_by_uri }}
-  {{ title }}
-{{ /get_content:related_by_uri }}
 
 {{ get_content:related_by_id }}
   {{ title }}

--- a/content/collections/tags/get_content.md
+++ b/content/collections/tags/get_content.md
@@ -45,7 +45,7 @@ For example, you might want to output some company information from your home pa
 
 ## Shorthand
 
-You may also use a shorthand syntax, where the second tag argument refers to a variable that contains a URI or ID.
+You may also use a shorthand syntax, where the second tag argument refers to a variable that contains an ID.
 
 ```
 ---


### PR DESCRIPTION
https://statamic.dev/upgrade-guide/v2-to-v3#tags