### PR TITLE
Correct fully qualified, absolute URL code example

### DIFF
--- a/content/collections/docs/multi-site.md
+++ b/content/collections/docs/multi-site.md
@@ -67,7 +67,7 @@ It can be a good idea to change this to a **fully qualified, absolute URL**. Thi
     ],
     'fr' => [
         // ...
-        'url' => env('APP_URL').'fr/'
+        'url' => env('APP_URL').'/fr/'
     ]
 ]
 ```


### PR DESCRIPTION
The currently shown version `env('APP_URL').'fr/'` is not working for me, the corrected one is. Not sure if this is the right approach / best practise but proposing the change anyway.