### PR TITLE
Fix typeo in new-antlers-parser

### DIFF
--- a/content/collections/docs/new-antlers-parser.md
+++ b/content/collections/docs/new-antlers-parser.md
@@ -1303,7 +1303,7 @@ The `@` can also be used to escape individual braces within tag parameters or st
 
 ```
 {{ partial:example attributes="class='@{font-bold: isImportant@}'" }}
-// attributes="class='{font-bold: isImportant"}'"
+// attributes="class='{font-bold: isImportant}'"
 ```
 
 ```


### PR DESCRIPTION
Just a quick typeo fix.

The example of rendered output had an extra <kbd>"</kbd>