### PR TITLE
Update vercel.md

### DIFF
--- a/content/collections/docs/vercel.md
+++ b/content/collections/docs/vercel.md
@@ -22,7 +22,7 @@ Add the following snippet to `build.sh` file to install PHP, Composer, and run t
 
 # Install PHP & WGET
 yum install -y amazon-linux-extras
-amazon-linux-extras enable php7.4
+amazon-linux-extras enable php8.1
 yum clean metadata
 yum install php php-{common,curl,mbstring,gd,gettext,bcmath,json,xml,fpm,intl,zip,imap}
 yum install wget


### PR DESCRIPTION
Should be 8.1 now.

Question though, why say include the APP_KEY but also generate in the build script?