### PR TITLE
Fix wrong path in readme

### DIFF
--- a/content/collections/docs/laravel.md
+++ b/content/collections/docs/laravel.md
@@ -56,7 +56,7 @@ Otherwise, the [Storing User Records](/users#storage) page should have instructi
 
 After Statamic is installed, you'll have 3 new directories in your project:
 - `content/`,
-- `users/`
+- `resources/users/`
 - `config/statamic/`
 
 :::tip


### PR DESCRIPTION
I just followed this install guide. The `users` folder was created in `resources`