### PR TITLE
Added missing '=>' to function declaration

### DIFF
--- a/content/collections/extending-docs/hooks.md
+++ b/content/collections/extending-docs/hooks.md
@@ -62,7 +62,7 @@ When you `reject` a hook, any other code using that hook will not be executed.
 Unless your intention is to stop the execution chain, you should always `resolve`, even when your code does nothing.
 
 ``` js
-Statamic.$hooks.on('example', (resolve, reject) {
+Statamic.$hooks.on('example', (resolve, reject) => {
     if (somethingShouldHappen) {
         doSomething();
     }


### PR DESCRIPTION
Minor fix; added missing '=>' to function declaration in hooks example.

P.S. Huge fan of Statamic!