### PR TITLE
Update urldecode/urlencode links

### DIFF
--- a/content/collections/modifiers/urldecode.md
+++ b/content/collections/modifiers/urldecode.md
@@ -6,7 +6,7 @@ modifier_types:
   - utility
 title: URL Decode
 ---
-URL-decodes a string. The inverse of [urlencode](#urlencode)
+URL-decodes a string. The inverse of [urlencode](https://statamic.dev/modifiers/urlencode)
 
 ```yaml
 string: I+just+want+%26+need+%24pecial+characters%21

--- a/content/collections/modifiers/urldecode.md
+++ b/content/collections/modifiers/urldecode.md
@@ -6,7 +6,7 @@ modifier_types:
   - utility
 title: URL Decode
 ---
-URL-decodes a string. The inverse of [urlencode](https://statamic.dev/modifiers/urlencode)
+URL-decodes a string. The inverse of [urlencode](/modifiers/urlencode)
 
 ```yaml
 string: I+just+want+%26+need+%24pecial+characters%21

--- a/content/collections/modifiers/urlencode.md
+++ b/content/collections/modifiers/urlencode.md
@@ -6,7 +6,7 @@ modifier_types:
   - utility
 title: URL Encode
 ---
-URL-encodes a string. The inverse of [urldecode](#urldecode)
+URL-encodes a string. The inverse of [urldecode]((https://statamic.dev/modifiers/urldecode)
 
 ```yaml
 string: I just want & need $pecial characters!

--- a/content/collections/modifiers/urlencode.md
+++ b/content/collections/modifiers/urlencode.md
@@ -6,7 +6,7 @@ modifier_types:
   - utility
 title: URL Encode
 ---
-URL-encodes a string. The inverse of [urldecode]((https://statamic.dev/modifiers/urldecode)
+URL-encodes a string. The inverse of [urldecode]((/modifiers/urldecode)
 
 ```yaml
 string: I just want & need $pecial characters!


### PR DESCRIPTION
After the docs were fixed these two modifiers were split to different pages; simply fixing the anchor links to now point to their respective pages.