### PR TITLE
add 'save' to the list of reserved words

### DIFF
--- a/content/collections/tips/reserved-words.md
+++ b/content/collections/tips/reserved-words.md
@@ -21,6 +21,7 @@ This is the list of reserved words you shouldn't use as field names, in addition
 - `resource`
 - `status`
 - `unless`
+- `save`
 - `value`
 
 :::warning

--- a/content/collections/tips/reserved-words.md
+++ b/content/collections/tips/reserved-words.md
@@ -19,9 +19,9 @@ This is the list of reserved words you shouldn't use as field names, in addition
 - `length`
 - `reference`
 - `resource`
+- `save`
 - `status`
 - `unless`
-- `save`
 - `value`
 
 :::warning


### PR DESCRIPTION
After hours of almost crying, I was able to pinpoint the following issue to the accidental use of the handle `save` in an entry.

---

When used, entries will trigger Events when being opened in the CP and also when accessed in the frontend. This pollutes the queue and might cause some headache.