### PR TITLE
`<template>` tags should only have one direct child element

### DIFF
--- a/content/collections/tags/form-create.md
+++ b/content/collections/tags/form-create.md
@@ -228,8 +228,10 @@ Finally, you will need to wire up the fields. With Alpine, this is done using `x
 
 ```
 <template x-if="{{ show_field:name }}">
-    <label>Name</label>
-    <input type="text" name="name" value="{{ old:name }}" x-model="name" />
+    <div class="p-2">
+        <label>Name</label>
+        <input type="text" name="name" value="{{ old:name }}" x-model="name" />
+    </div>
 </template>
 ```
 
@@ -268,8 +270,10 @@ If you are hardcoding your inputs, you will need adjust your `x-model` to follow
 
 ```
 <template x-if="{{ show_field:name }}">
-    <label>Name</label>
-    <input type="text" name="name" value="{{ old:name }}" x-model="contact_form.name" />
+    <div class="p-2">
+        <label>Name</label>
+        <input type="text" name="name" value="{{ old:name }}" x-model="contact_form.name" />
+    </div>
 </template>
 ```
 


### PR DESCRIPTION
Found when testing form conditions on https://github.com/statamic/cms/pull/7778 that `<template x-if="...">` tags should only have one direct child element.