### PR TITLE
Fix incorrect CSS path in code example

### DIFF
--- a/content/collections/extending-docs/control-panel.md
+++ b/content/collections/extending-docs/control-panel.md
@@ -27,7 +27,7 @@ class AppServiceProvider
     {
         Statamic::vite('app', [
             'resources/js/cp.js',
-            'resources/js/cp.css'
+            'resources/css/cp.css'
         ]);
     }
 }


### PR DESCRIPTION
The path for cp.css was incorrect in the example code 🙃