### PR TITLE
Update cp-navigation.md code snippet

### DIFF
--- a/content/collections/extending-docs/cp-navigation.md
+++ b/content/collections/extending-docs/cp-navigation.md
@@ -29,7 +29,7 @@ Let's assume we're creating a Store addon, and want to add a `Store` nav item to
 ```php
 use Statamic\Facades\CP\Nav;
 
-public function boot()
+public function bootAddon()
 {
     Nav::extend(function ($nav) {
         $nav->content('Store')


### PR DESCRIPTION
Update code snippet to use `bootAddon` instead of `boot`. If you'd rather use `boot` `parent::boot();` should also be added.