### PR TITLE
Update term-repository.md to clarify Locales

### DIFF
--- a/content/collections/repositories/term-repository.md
+++ b/content/collections/repositories/term-repository.md
@@ -78,7 +78,7 @@ $term = Term::make()->taxonomy('tags')->slug('my-term');
 Data is stored on a term on a per site basis, even if you only are using a single site.
 
 ```php
-$term->dataForLocale('en', $data);
+$term->dataForLocale('en', $data); // check your default locale in `sites.php`. It may be something other than 'en'
 $term->dataForLocale('fr', $frenchData);
 ```
 


### PR DESCRIPTION
Users may run into the following error when attempting to create a locale:

```

   Error

  Call to a member function all() on null

  at vendor/statamic/cms/src/Taxonomies/Term.php:103
     99▕     {
    100▕         $localizations = clone $this->data;
    101▕
    102▕         $array = Arr::removeNullValues(
  ➜ 103▕             $localizations->pull($this->defaultLocale())->all()
    104▕         );
    105▕
    106▕         // todo: add published bool (for each locale?)
    107▕

      +7 vendor frames

  8   app/Console/Commands/ImportTags.php:42
      Statamic\Taxonomies\Term::save()
      +12 vendor frames

  21  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

This is because the locale specified in the docs is `en`, when in reality, the default for most users is `default`.

There are multiple ways the docs could be improved here, either by specifying the `default` locale in the example, or by adding another query without multi-site mode. I've implemented the first one using a comment, but I think either may be effective. We could also use a hint here.