### PR TITLE
Update example URL for asset tag

### DIFF
--- a/content/collections/tags/asset.md
+++ b/content/collections/tags/asset.md
@@ -18,7 +18,7 @@ The Asset tag's primary purpose is to retrieve [Assets](/assets) by their URL.  
 ## Example
 
 ```
-{{ asset url="/img/brand/logo.png" }}
+{{ asset url="/assets/img/brand/logo.png" }}
   <img src="{{ url }}" alt="{{ alt }}">
 {{ /asset }}
 ```


### PR DESCRIPTION
*Might* be less confusing for new users - path matches the upload directory when using the default asset container in a new Statamic install.