### PR TITLE
is external url modifier docs

### DIFF
--- a/content/collections/modifiers/is_external_url.md
+++ b/content/collections/modifiers/is_external_url.md
@@ -11,14 +11,17 @@ Returns `true` if a string is an external URL.
 ```yaml
 google_url: http://google.com/
 entry_url: /waffles
+not_a_url: bacon
 ```
 
 ```
 {{ if google_url | is_external_url }}
 {{ if entry_url | is_external_url }}
+{{ if not_a_url | is_external_url }}
 ```
 
 ```html
 true
+false
 false
 ```

--- a/content/collections/modifiers/is_external_url.md
+++ b/content/collections/modifiers/is_external_url.md
@@ -1,0 +1,24 @@
+---
+id: 4cb0f243-72f4-45a1-83d3-d72209907875
+blueprint: modifiers
+modifier_types:
+  - string
+  - conditions
+title: 'Is External Url'
+---
+Returns `true` if a string is an external URL.
+
+```yaml
+google_url: http://google.com/
+entry_url: /waffles
+```
+
+```
+{{ if google_url | is_external_url }}
+{{ if entry_url | is_external_url }}
+```
+
+```html
+true
+false
+```


### PR DESCRIPTION
Just a simple docs page for the new `is_external_url` modifier [statamic/cms PR 8351](https://github.com/statamic/cms/pull/8351)

Follows the same setup as the `is_url` entry but also not sure if the code samples should be improved. 

The antlers, as is, is invalid and doesn't return the HTML the docs suggest.

Could/should this (and `is_url`) be re-worked to be more copy-and-paste complete? Or is this adequate for the use case. It makes total sense... but just questioning whether it needs greater detail. Or even a use case.

Happy to discuss and update as needed.