### PR TITLE
Fixed wrong default table name

### DIFF
--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -49,7 +49,7 @@ You will need to run migrations to prepare your database for Statamic's user, pa
     ```php
     'activations' => [
         'provider' => 'users',
-        'table' => 'password_activations',
+        'table' => 'password_activation_tokens',
         'expire' => 4320,
         'throttle' => 60,
     ],


### PR DESCRIPTION
Hello there!
While trying to install Statamic 4 into existing project, i followed this guide. However, database name is different from one created by php please auth:migration. This change fixes this issue.