### PR TITLE
Update vite.md for vite:asset

### DIFF
--- a/content/collections/tags/vite.md
+++ b/content/collections/tags/vite.md
@@ -56,5 +56,5 @@ When using these options, please make sure to also adjust your `vite.config.js` 
 To process static assets in your Antlers files with Vite, as described in the [Laravel's Vite Docs](https://laravel.com/docs/master/vite#blade-processing-static-assets), you should use:
 
 ```html
-<img src="{{ vite::asset src="resources/images/logo.png" }}">
+<img src="{{ vite:asset src="resources/images/logo.png" }}">
 ```


### PR DESCRIPTION
An extra colon was present for the example code using vite:asset