### PR TITLE
Reserved Words: Add `count` to reserved words list

### DIFF
--- a/content/collections/tips/reserved-words.md
+++ b/content/collections/tips/reserved-words.md
@@ -23,6 +23,7 @@ This is the list of reserved words you shouldn't use as field names, in addition
 - `status`
 - `unless`
 - `value`
+- `count`
 
 :::warning
 Some of these _may_ work as field names in some circumstances, but can have unintended consequences, like overriding global data, behaviors, or creating issues with Vue components inside the Control Panel.


### PR DESCRIPTION
Using **count** as a field name in a field set (e.g. show limited number/count of entries), which might be used inside a loop e.g. repeater field can have unintended consequences.