### PR TITLE
Update quick-start-guide.md

### DIFF
--- a/content/collections/docs/quick-start-guide.md
+++ b/content/collections/docs/quick-start-guide.md
@@ -146,7 +146,7 @@ There's really no perfect place to mention this, but here is as good as any.
 
 The default install uses [TailwindCSS](https://tailwindcss.com/docs/just-in-time-mode) in Just In Time mode, so anytime you change classes in your HTML you'll need to recompile your CSS.
 
-This is super easy and happens automatically when you run `npm run watch` from the terminal in your project directory (as long as you've run `npm install` first).
+This is super easy and happens automatically when you run `npm run dev` from the terminal in your project directory (as long as you've run `npm install` first).
 :::
 
 ## Now let's build a blog


### PR DESCRIPTION
Now vite is the default `npm run watch` needs updated to `npm run dev` (I think!)