### PR TITLE
add missing parameter to published() call

### DIFF
--- a/content/collections/extending-docs/data.md
+++ b/content/collections/extending-docs/data.md
@@ -110,7 +110,7 @@ Once you have an instance, you can manipulate it using various methods the same 
 use Statamic\Facades\Entry;
 
 $entry = Entry::make()
-            ->published()
+            ->published(true)
             ->data(['title' => 'About us', 'subtitle' => 'We are awesome'])
             ->etc(); // and so on...
 


### PR DESCRIPTION
In the doc example we are chaining calls to create an Entry : 
```
Entry::make()
            ->published()
            ->data(['title' => 'About us', 'subtitle' => 'We are awesome'])
            ->etc(); // and so on...
```

but the "published()" method return a boolean if no parameter is passed, so the "->data()" chained call breaks.

When passing a parameter to "published()", "this" is returned so the chained call works.

