### PR TITLE
[4.x] Adds tip for the default icon set

### DIFF
--- a/content/collections/extending-docs/cp-navigation.md
+++ b/content/collections/extending-docs/cp-navigation.md
@@ -52,6 +52,10 @@ Nav::extend(function ($nav) {
 
 If you wish to use a custom SVG or one from the [Streamline Icon Pack](https://app.streamlinehq.com/icons/streamline-light) that's not included in Statamic, you may pass the SVG icon to the `icon()` method, in place of an icon name.
 
+:::tip
+You can access the complete set of default icons for the icon() method in the vendor files located at vendor/statamic/cms/resources/svg/icons. Alternatively, you can also view them directly [on GitHub](https://github.com/statamic/cms/tree/4.x/resources/svg/icons/light)
+:::
+
 ```php
 Nav::extend(function ($nav) {
     $nav->create('Store')


### PR DESCRIPTION
This PR adds a "tip" section when talking about Icons to direct people to the available icons that can be used.