### PR TITLE
Collections: Add more examples and detailed explanation for collection routing

### DIFF
--- a/content/collections/docs/collections.md
+++ b/content/collections/docs/collections.md
@@ -227,8 +227,7 @@ For non-structured collections, you can choose which field and direction to sort
 
 ## Routing
 
-Entries receive their URLs from their collection's route setting. You can use standard meta variables in addition to the variables from the collection's blueprint to define your route rule.
-You can also use [computed values](/computed-values) or even use Antlers syntax to achieve advanced stuff.
+Entries receive their URLs from their collection's route setting. You can use standard meta variables in addition to the variables from the collection's blueprint to define your route rule. You can even use [computed values](/computed-values) or Antlers to do advanced things.
 
 ``` yaml
 route: /blog/{slug}
@@ -281,21 +280,21 @@ route: /{parent_uri}/{slug}.html
 ```
 
 #### Organizing sports brackets with structures
-
-Here we use the "team" field, defined in the collection's blueprint and the "depth" meta variable
+Here's how we use the `depth` variable, along with the `team_name` field from the entry's blueprint.
 
 ``` yaml
-route: /tournament/round-{depth}/{team}
+route: /tournament/round-{depth}/{team_name}
 # example: /tournament/round-4/chicago-bulls
 ```
 
-#### For when your entry depend on it's related content
+#### Using fields from related entries
+For example, if you have a `category` field in your Products collection and you'd like to your product URLs to depend on it, you can configure a [computed value](/computed-values) to return the category URL, then use that computed value in your collection's route:
 
-For instance, if you have a "category" field in your "products" collection and want your products url depend on it. 
-You can use "computed values" to grab your category url
+``` php
+// app/Providers/AppServiceProvider.php
 
-```php
-// define the computed value in a service provider
+use Statamic\Facades\Collection;
+
 Collection::computed('products', 'category_url', function ($entry, $value) {
     return $entry->category?->url();
 });
@@ -303,7 +302,7 @@ Collection::computed('products', 'category_url', function ($entry, $value) {
 
 ``` yaml
 route: '{{ category_url }}/{{ slug }}'
-# example: /wooden-toys/steam-locomotive
+# example: /categories/wooden-toys/steam-locomotive
 ```
 
 #### Using Antlers to organize gaming articles

--- a/content/collections/docs/collections.md
+++ b/content/collections/docs/collections.md
@@ -228,6 +228,7 @@ For non-structured collections, you can choose which field and direction to sort
 ## Routing
 
 Entries receive their URLs from their collection's route setting. You can use standard meta variables in addition to the variables from the collection's blueprint to define your route rule.
+You can also use [computed values](/computed-values) or even use Antlers syntax to achieve advanced stuff.
 
 ``` yaml
 route: /blog/{slug}
@@ -280,12 +281,32 @@ route: /{parent_uri}/{slug}.html
 ```
 
 #### Organizing sports brackets with structures
+
+Here we use the "team" field, defined in the collection's blueprint and the "depth" meta variable
+
 ``` yaml
 route: /tournament/round-{depth}/{team}
 # example: /tournament/round-4/chicago-bulls
 ```
 
-#### Organizing gaming articles
+#### For when your entry depend on it's related content
+
+For instance, if you have a "category" field in your "products" collection and want your products url depend on it. 
+You can use "computed values" to grab your category url
+
+```php
+// define the computed value in a service provider
+Collection::computed('products', 'category_url', function ($entry, $value) {
+    return $entry->category?->url();
+});
+```
+
+``` yaml
+route: '{{ category_url }}/{{ slug }}'
+# example: /wooden-toys/steam-locomotive
+```
+
+#### Using Antlers to organize gaming articles
 
 You can even use Antlers to get more complicated. Here we'll include the [mounted](#mounting) entry at the top level.
 


### PR DESCRIPTION
This PR tried to achieve 2 goals : 

- insist more on the fact that we can use, not only meta variable in collection routes but also, fields defined in the blueprint
- suggest that for advanced stuff we can also use field using computed values.

Why ? because I had this project with a "products" collection and a "categories" collection (each product belonging to a category). For SEO purpose, product url was supposed to be "/category_url/product_slug" or even "/master_category/child_category/product_slug" (when using nested categories) .

I had hard time figuring out how to achieve that while reading the doc carefully. 

I first attempted to recreate custom routes, but it was quite complicated and implied a lot of side effects (like product urls not included in seo-pro sitemap ...)

then I tried to use Antlers in my routes : 

``` yaml 
route: "{{ category.url() }}/{{ slug }}"
```

But it triggers an error, so my last attempt was to use that computed values, and it worked beautifully (without side effects). 