### PR TITLE
Antlers: Fix link to legacy string/shorthand syntax

### DIFF
--- a/content/collections/docs/antlers.md
+++ b/content/collections/docs/antlers.md
@@ -376,7 +376,7 @@ You can even create [Macros](/modifiers/macro) to combine sets of often used mod
 
 #### Legacy Syntax
 
-The New Antlers Parser still supports what we're now calling the "[Legacy Syntax](/antlers#stringshorthand-style)" styles, and will continue to do so until Statamic 4.0.
+The New Antlers Parser still supports what we're now calling the "[Legacy Syntax](/antlers-legacy#stringshorthand-style)" styles, and will continue to do so until Statamic 4.0.
 
 ### Creating Variables
 


### PR DESCRIPTION
I realised this link was pointing to the *current* Antlers page, rather than the *legacy* Antlers page.

Tweet: https://twitter.com/godismyjudge95/status/1707782374568722835