### PR TITLE
Fix code within hint blocks

### DIFF
--- a/app/Markdown/Hint/Hint.php
+++ b/app/Markdown/Hint/Hint.php
@@ -18,7 +18,8 @@ class Hint extends AbstractBlock implements StringContainerInterface
         if (count($words) > 1) {
 
             array_shift($words);
-            return join(' ', $words);
+
+            return implode(' ', $words);
         }
 
         if ($words[0] === 'tip') {

--- a/app/Markdown/Hint/HintParser.php
+++ b/app/Markdown/Hint/HintParser.php
@@ -14,74 +14,74 @@ use League\CommonMark\Util\RegexHelper;
 
 class HintParser extends AbstractBlockContinueParser implements BlockContinueParserWithInlinesInterface
 {
-        /** @psalm-readonly */
-        private Hint $block;
+    /** @psalm-readonly */
+    private Hint $block;
 
-        /** @var ArrayCollection<string> */
-        private ArrayCollection $strings;
+    /** @var ArrayCollection<string> */
+    private ArrayCollection $strings;
 
-        public function __construct()
-        {
-            $this->block = new Hint();
-            $this->strings = new ArrayCollection();
+    public function __construct()
+    {
+        $this->block = new Hint();
+        $this->strings = new ArrayCollection();
+    }
+
+    public function getBlock(): Hint
+    {
+        return $this->block;
+    }
+
+    public function isContainer(): bool
+    {
+        return false;
+    }
+
+    public function canContain(AbstractBlock $childBlock): bool
+    {
+        return false;
+    }
+
+    public function canHaveLazyContinuationLines(): bool
+    {
+        return true;
+    }
+
+    public function parseInlines(InlineParserEngineInterface $inlineParser): void
+    {
+        $inlineParser->parse($this->block->getLiteral(), $this->block);
+    }
+
+    public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue
+    {
+        if ($cursor->getLine() === ':::') {
+            return BlockContinue::finished();
         }
 
-        public function getBlock(): Hint
-        {
-            return $this->block;
+        $cursor->advanceToNextNonSpaceOrTab();
+        $cursor->advanceBySpaceOrTab();
+
+        return BlockContinue::at($cursor);
+    }
+
+    public function addLine(string $line): void
+    {
+        $this->strings[] = $line;
+    }
+
+    public function closeBlock(): void
+    {
+        // first line becomes info string
+        $firstLine = $this->strings->first();
+        if ($firstLine === false) {
+            $firstLine = '';
         }
 
-        public function isContainer(): bool
-        {
-            return false;
+        $this->block->setHeader(RegexHelper::unescape(\trim($firstLine)));
+
+        if ($this->strings->count() === 1) {
+            $this->block->setLiteral('');
+        } else {
+            $this->block->setLiteral(\implode("\n", $this->strings->slice(1))."\n");
         }
-
-        public function canContain(AbstractBlock $childBlock): bool
-        {
-            return false;
-        }
-
-        public function canHaveLazyContinuationLines(): bool
-        {
-            return true;
-        }
-
-        public function parseInlines(InlineParserEngineInterface $inlineParser): void
-        {
-            $inlineParser->parse($this->block->getLiteral(), $this->block);
-        }
-
-        public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue
-        {
-            if ($cursor->getLine() === ':::') {
-                return BlockContinue::finished();
-            }
-
-            $cursor->advanceToNextNonSpaceOrTab();
-            $cursor->advanceBySpaceOrTab();
-
-            return BlockContinue::at($cursor);
-        }
-
-        public function addLine(string $line): void
-        {
-            $this->strings[] = $line;
-        }
-
-        public function closeBlock(): void
-        {
-            // first line becomes info string
-            $firstLine = $this->strings->first();
-            if ($firstLine === false) {
-                $firstLine = '';
-            }
-
-            $this->block->setHeader(RegexHelper::unescape(\trim($firstLine)));
-
-            if ($this->strings->count() === 1) {
-                $this->block->setLiteral('');
-            } else {
-                $this->block->setLiteral(\implode("\n", $this->strings->slice(1)) . "\n");
-            }
-        }
+    }
 }

--- a/app/Markdown/Hint/HintRenderer.php
+++ b/app/Markdown/Hint/HintRenderer.php
@@ -60,7 +60,7 @@ final class HintRenderer implements NodeRendererInterface
     private function renderWatch(Hint $node, ChildNodeRendererInterface $childRenderer, array $attrs)
     {
         $caption = new HtmlElement(
-            'p',
+            'div',
             ['class' => 'caption'],
             $childRenderer->renderNodes($node->children())
         );

--- a/app/Markdown/Hint/HintRenderer.php
+++ b/app/Markdown/Hint/HintRenderer.php
@@ -10,7 +10,7 @@ use League\CommonMark\Util\HtmlElement;
 final class HintRenderer implements NodeRendererInterface
 {
     /**
-     * @param Hint $node
+     * @param  Hint  $node
      *
      * {@inheritDoc}
      *
@@ -24,11 +24,11 @@ final class HintRenderer implements NodeRendererInterface
         isset($attrs['class']) ? $attrs['class'] .= ' hint' : $attrs['class'] = 'hint';
 
         if ($type = $node->getType()) {
-            $attrs['class'] = isset($attrs['class']) ? $attrs['class'] . ' ' : '';
+            $attrs['class'] = isset($attrs['class']) ? $attrs['class'].' ' : '';
             $attrs['class'] .= $type;
         }
 
-        if ($type === "watch") {
+        if ($type === 'watch') {
             return $this->renderWatch($node, $childRenderer, $attrs);
         }
 
@@ -50,9 +50,9 @@ final class HintRenderer implements NodeRendererInterface
         return new HtmlElement(
             'div',
             $attrs,
-            "\n" .
-            $title . "\n" .
-            $content .
+            "\n".
+            $title."\n".
+            $content.
             "\n"
         );
     }

--- a/app/Markdown/Hint/HintStartParser.php
+++ b/app/Markdown/Hint/HintStartParser.php
@@ -16,10 +16,15 @@ class HintStartParser implements BlockStartParserInterface
         }
 
         $fence = $cursor->match('/^(?:\:{3,}(?!.*`))/');
+
         if ($fence === null) {
             return BlockStart::none();
         }
 
-        return BlockStart::of(new HintParser())->at($cursor);
+        $headerText = $cursor->getRemainder();
+
+        $cursor->advanceToEnd();
+
+        return BlockStart::of(new HintParser($headerText))->at($cursor);
     }
 }

--- a/content/collections/docs/content-queries.md
+++ b/content/collections/docs/content-queries.md
@@ -8,11 +8,9 @@ intro: 'Statamic provides a fluent query builder interacting with your content a
 
 Each of the core Statamic data types has its own Facade used to access an underlying repository class so you can query, create, modify, and delete content. Working with data in this manner is usually done in a [Controller](/controllers), with any retrieved data being passed into a view.
 
-:::callout /extending/repositories
-Learn how Statamic can use different storage methods!
-:::
-
 These methods will work no matter which driver you're using — flat files, Eloquent/MySQL, or any other custom repo driver.
+
+[Learn how Statamic can use different storage methods!](/extending/repositories)
 
 :::tip
 While Statamic's Query builder is very similar to [Laravel's Query Builder](https://laravel.com/docs/8.x/queries), they are **completely separate implementations**.

--- a/resources/css/components.css
+++ b/resources/css/components.css
@@ -51,8 +51,12 @@
             @apply relative;
         }
 
-        p.caption {
-            @apply relative float-right -top-px bg-white right-0 bottom-0 font-mono-alt border subpixel-antialiased italic text-black text-sm font-bold rotate-0 px-3 py-1 shadow-yellow-md;
+        .caption {
+            @apply relative float-right -top-px bg-white right-0 bottom-0 font-mono-alt border subpixel-antialiased italic text-black font-bold rotate-0 px-3 py-1 shadow-yellow-md;
+
+            p {
+                @apply text-sm;
+            }
         }
     }
 

--- a/resources/css/components.css
+++ b/resources/css/components.css
@@ -87,29 +87,6 @@
     }
 }
 
-.hint.callout {
-    display: none;
-}
-
-@screen xl {
-    .hint.callout {
-        @apply border-none block bg-transparent relative shadow-none h-0 m-0 p-0;
-        .hint-title { display: none; }
-        a {
-            @apply bg-white hover:bg-mint no-underline absolute p-3 w-64 border shadow-stack-sm -right-64 text-black font-normal;
-            p {
-                @apply text-sm;
-            }
-        }
-    }
-}
-
-@screen 2xl {
-    .hint.callout a {
-        @apply -right-80;
-    }
-}
-
 
 /* Video Embed */
 /* -------------------------------------------------- */


### PR DESCRIPTION
Fixes #1120

Code blocks (or really any block level elements) inside our "hints" were broken since the upgrade to commonmark 2.

The issue mentioned just one page, but there were plenty of others, such as on:

- https://statamic.dev/data-inheritance
- https://statamic.dev/oauth
- https://statamic.dev/multi-site

Now that text within the hints are rendered as paragraphs, the css change in this PR is necessary to get the video blocks to look the same.

I also removed the "callout" version of the hint since that was (probably unintentionally) dropped during the upgrade, and there's only one usage anyway.

