### PR TITLE
Bard: Add note about configuring asset container when image button is toggled

### DIFF
--- a/content/collections/fieldtypes/bard.md
+++ b/content/collections/fieldtypes/bard.md
@@ -23,6 +23,8 @@ options:
 
       These are the defaults:
       ![Bard Buttons](/img/fieldtypes/screenshots/bard-buttons.png) {.mt-4}
+
+      When you have the `image` button toggled, make sure to define an Asset Container in the Bard field's settings, otherwise the button won't show.
   -
     name: target_blank
     type: boolean


### PR DESCRIPTION
This PR adds a short note to the Bard page, making sure people define an 'Asset Container' after toggling the Image button. Otherwise, they toggle it and don't see the button appear which is slightly confusing.

Closes #1122.