### PR TITLE
Add `preProcessIndex` to `Relationship` fieldtypes

### DIFF
--- a/content/collections/extending-docs/relationship-fieldtypes.md
+++ b/content/collections/extending-docs/relationship-fieldtypes.md
@@ -46,7 +46,7 @@ class Tweets extends Relationship
 
 There are a handful of methods and properties inside the `Relationship` class, and you can override them to control how it functions.
 
-There are three main areas you will want to customize. The index items, the selected item data, and the listings data.
+There are three main areas you will want to customize. The index items, the selected item data, and the listing data.
 
 ## Index Items
 
@@ -128,11 +128,11 @@ public function getItemData($values, $site = null)
 }
 ```
 
-### Listings Data
+### Listing Data
 
-When your field's data is going to be displayed in a listings view, like a entries listing (or an entries selector), you need to override the `preProcessIndex`.
+When field data is to be displayed in a listing view — an entries listing or entries selector for example, the `preProcessIndex` will need to be overwritten.
 
-In our Twitter field, maybe we'd like to show only the text:
+In our Twitter field, we'd like to show only the text:
 
 ```php
 public function preProcessIndex($data)
@@ -144,8 +144,6 @@ public function preProcessIndex($data)
 ```
 
 ## Creating Items
-
-Todo.
 
 To disable creation of items, you can add the canCreate property.
 

--- a/content/collections/extending-docs/relationship-fieldtypes.md
+++ b/content/collections/extending-docs/relationship-fieldtypes.md
@@ -129,7 +129,7 @@ public function getItemData($values, $site = null)
 
 ### Listing Data
 
-When field data is to be displayed in a listing view — an entries listing or entries selector for example, you may customize the display by overwriting the `preProcessIndex` method.
+When field data is to be displayed in a listing view (eg. in the entries listing table or the entry fieldtype), you may customize the display by overwriting the `preProcessIndex` method.
 
 In our Twitter field, let's show only the text:
 
@@ -186,7 +186,7 @@ Vue.component('TwitterRelationshipItem', require('./TwitterRelationshipItem.vue'
 
 ``` vue
 <template>
-    <div class="mb-1 item ">
+    <div class="mb-1 item">
         <div class="item-move">&nbsp;</div>
         <div class="item-inner">
             <div class="p-3">

--- a/content/collections/extending-docs/relationship-fieldtypes.md
+++ b/content/collections/extending-docs/relationship-fieldtypes.md
@@ -4,7 +4,6 @@ template: page
 updated_by: 42bb2659-2277-44da-a5ea-2f1eed146402
 updated_at: 1569347303
 intro: The Relationship fieldtype is one of the more powerful fields in Statamic's core. So powerful, in fact, that it earns its very own page in the docs. This is that page.
-stage: 1
 id: 06813e5d-158e-4318-aa4a-b29fd87d107f
 ---
 By default, the relationship fieldtype lets you select entries from various collections as well as create and edit items on the fly from _within_ the field.
@@ -130,9 +129,9 @@ public function getItemData($values, $site = null)
 
 ### Listing Data
 
-When field data is to be displayed in a listing view — an entries listing or entries selector for example, the `preProcessIndex` will need to be overwritten.
+When field data is to be displayed in a listing view — an entries listing or entries selector for example, you may customize the display by overwritting the `preProcessIndex` method.
 
-In our Twitter field, we'd like to show only the text:
+In our Twitter field, let's show only the text:
 
 ```php
 public function preProcessIndex($data)

--- a/content/collections/extending-docs/relationship-fieldtypes.md
+++ b/content/collections/extending-docs/relationship-fieldtypes.md
@@ -46,7 +46,7 @@ class Tweets extends Relationship
 
 There are a handful of methods and properties inside the `Relationship` class, and you can override them to control how it functions.
 
-There are two main areas you will want to customize. The index items and the selected item data.
+There are three main areas you will want to customize. The index items, the selected item data, and the listings data.
 
 ## Index Items
 
@@ -128,6 +128,21 @@ public function getItemData($values, $site = null)
 }
 ```
 
+### Listings Data
+
+When your field's data is going to be displayed in a listings view, like a entries listing (or an entries selector), you need to override the `preProcessIndex`.
+
+In our Twitter field, maybe we'd like to show only the text:
+
+```php
+public function preProcessIndex($data)
+{
+    $tweets = Twitter::getStatusesLookup(['id' => implode(',', $data)]);
+
+    return collect($tweets)->map(fn($tweet) => $tweet->text)->join(', ');
+}
+```
+
 ## Creating Items
 
 Todo.
@@ -174,11 +189,11 @@ Vue.component('TwitterRelationshipItem', require('./TwitterRelationshipItem.vue'
 
 ``` vue
 <template>
-    <div class="item mb-1 ">
+    <div class="mb-1 item ">
         <div class="item-move">&nbsp;</div>
         <div class="item-inner">
             <div class="p-3">
-                <p class="text-lg mb-2">{{ item.text }}</p>
+                <p class="mb-2 text-lg">{{ item.text }}</p>
                 <p class="text-grey">{{ item.user }} – {{ item.date_relative }}</p>
             </div>
         </div>

--- a/content/collections/extending-docs/relationship-fieldtypes.md
+++ b/content/collections/extending-docs/relationship-fieldtypes.md
@@ -129,7 +129,7 @@ public function getItemData($values, $site = null)
 
 ### Listing Data
 
-When field data is to be displayed in a listing view — an entries listing or entries selector for example, you may customize the display by overwritting the `preProcessIndex` method.
+When field data is to be displayed in a listing view — an entries listing or entries selector for example, you may customize the display by overwriting the `preProcessIndex` method.
 
 In our Twitter field, let's show only the text:
 


### PR DESCRIPTION
You need to override `preProcessIndex` when your data might appear in an entries listing.