### PR TITLE
Improve "Using an Independent Authentication Guard" docs

### DIFF
--- a/content/collections/tips/storing-laravel-users-in-files.md
+++ b/content/collections/tips/storing-laravel-users-in-files.md
@@ -23,10 +23,3 @@ If you've installed Statamic into an existing Laravel application, it will be ex
         ],
     ],
    ```
-3. Uncomment the `users` store in `config/statamic/stache.php`.
-    ``` php
-    'users' => [
-        'class' => Stores\UsersStore::class,
-        'directory' => base_path('users'),
-    ],
-    ```

--- a/content/collections/tips/using-an-independent-authentication-guard.md
+++ b/content/collections/tips/using-an-independent-authentication-guard.md
@@ -8,38 +8,23 @@ categories:
 updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
 updated_at: 1622821437
 ---
-By default, Statamic comes configured to use the default auth guard.
+By default, Statamic comes configured to use the default auth guard. This means that any users will be considered Statamic's users.
 
-This means that any users will be considered Statamic's users.
+If your application's users won't be interacting with Statamic and only a few users will actually be using the Control Panel, it might make sense for you to store your application's users in a database and your Statamic users in YAML files.
 
-An example wanting to change this could be if your application's users would not be interacting with Statamic, and only one or a few users would be using the Control Panel. It would be possible to keep your Statamic users in yaml files, and your app's users in a database.
+To separate Statamic's users from those of your Laravel application, you'll need to setup two user guards & two user providers in your `config/auth.php` config file.
 
-If you'd like Statamic to use its own guards, you can configure it that way in your config files.
-
-```php
-// config/statamic/users.php
-
-'guards' => [
-    'cp' => 'statamic', // the guard when using the cp
-    'web' => 'statamic', // the guard when using Statamic frontend routes
-],
-```
-
-Any non-Statamic routes (e.g. any routes you've manually added to routes/web.php) will be unaffected by the above config. They'll be using whatever your "default" guard is.
+You'll need one user guard/provider for your Eloquent users and one for your Statamic users:
 
 ```php
 // config/auth.php
-
-'defaults' => [
-  'guard' => 'web',
-  'passwords' => 'users',
-],
 
 'guards' => [
     'web' => [
         'driver' => 'session',
         'provider' => 'users',
     ],
+    
     'statamic' => [
         'driver' => 'session',
         'provider' => 'statamic',
@@ -51,9 +36,80 @@ Any non-Statamic routes (e.g. any routes you've manually added to routes/web.php
         'driver' => 'eloquent',
         'model' => \App\User::class,
     ],
+    
     'statamic' => [
         'driver' => 'statamic',
     ],
 ],
 ```
-In this example we'll use the custom `statamic` auth guard to authenticate users using the statamic driver. Following the steps in [Storing Laravel Users in Files](https://statamic.dev/tips/storing-laravel-users-in-files) we can have some users stored in the database and Statamic users stored in files.
+
+In the above example, the  `statamic`  guard is used to authenticate users using Statamic's flat-file driver and the `web` guard is used to authenticate users using Laravel's built-in Eloquent driver. 
+
+While you're in the `config/auth.php` file, ensure you have separate reset & activation brokers for each of the providers (two for the Statamic driver & two for the Eloquent driver):
+
+```php
+'passwords' => [
+	'resets' => [
+		'provider' => 'users',
+		'table' => 'password_reset_tokens',
+		'expire' => 60,
+		'throttle' => 60,
+	],
+
+	'activations' => [
+		'provider' => 'users',
+		'table' => 'password_activation_tokens',
+		'expire' => 4320,
+		'throttle' => 60,
+	],
+
+	'statamic_resets' => [
+		'provider' => 'statamic',
+		'table' => 'password_resets',
+		'expire' => 60,
+		'throttle' => 60,
+	],
+
+	'statamic_activations' => [
+		'provider' => 'statamic',
+		'table' => 'password_activations',
+		'expire' => 4320,
+		'throttle' => 60,
+	],
+],
+```
+
+Next, in Statamic's `users.php` configuration file, you'll want to configure which user guard should be used on the frontend and which should be used for the Control Panel:
+
+In the example below, we're using the `statamic` driver for Control Panel users and the `web` driver for frontend users.
+
+```php
+// config/statamic/users.php
+
+'guards' => [
+    'cp' => 'statamic',
+    'web' => 'web',
+],
+```
+
+You should also ensure the `passwords` is setup to point to the correct reset & activation configs:
+
+```php
+'passwords' => [
+	'resets' => 'statamic_resets',
+	'activations' => 'statamic_activations',
+],
+```
+
+## Non-Statamic routes
+
+It's worth noting that any non-Statamic routes (eg. any you've manually added in your `routes/web.php` file) will be unaffected by the config changes
+
+These routes will use whichever guard you have set to as the "default" in your `config/auth.php` file:
+
+```php
+'defaults' => [
+  'guard' => 'web',
+  'passwords' => 'users',
+],
+```

--- a/content/collections/tips/using-an-independent-authentication-guard.md
+++ b/content/collections/tips/using-an-independent-authentication-guard.md
@@ -8,13 +8,13 @@ categories:
 updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
 updated_at: 1622821437
 ---
-By default, Statamic comes configured to use the default auth guard. This means that any users will be considered Statamic's users.
+By default, Statamic comes configured to use the default auth guard. This means that your application's users will also be considered Statamic users.
 
 If your application's users won't be interacting with Statamic and only a few users will actually be using the Control Panel, it might make sense for you to store your application's users in a database and your Statamic users in YAML files.
 
 To separate Statamic's users from those of your Laravel application, you'll need to setup two user guards & two user providers in your `config/auth.php` config file.
 
-You'll need one user guard/provider for your Eloquent users and one for your Statamic users:
+You'll need one user guard & user provider for your Eloquent users and another for your Statamic users:
 
 ```php
 // config/auth.php
@@ -24,7 +24,7 @@ You'll need one user guard/provider for your Eloquent users and one for your Sta
         'driver' => 'session',
         'provider' => 'users',
     ],
-    
+
     'statamic' => [
         'driver' => 'session',
         'provider' => 'statamic',
@@ -36,14 +36,14 @@ You'll need one user guard/provider for your Eloquent users and one for your Sta
         'driver' => 'eloquent',
         'model' => \App\User::class,
     ],
-    
+
     'statamic' => [
         'driver' => 'statamic',
     ],
 ],
 ```
 
-In the above example, the  `statamic`  guard is used to authenticate users using Statamic's flat-file driver and the `web` guard is used to authenticate users using Laravel's built-in Eloquent driver. 
+In the above example, the  `statamic`  guard is used to authenticate users using Statamic's flat-file driver and the `web` guard is used to authenticate users using Laravel's built-in Eloquent driver.
 
 While you're in the `config/auth.php` file, ensure you have separate reset & activation brokers for each of the providers (two for the Statamic driver & two for the Eloquent driver):
 


### PR DESCRIPTION
This pull request aims to improve the "Using an Independent Authentication Guard" page in the documentation. 

I've tried to make the docs a little bit clearer and also included instructions on making password resets & activations work (otherwise, when you try to do a password reset, it'll try to use whatever provider the `resets` and `activations` brokers are set to).  

This PR also tweaks the "Storing Laravel Users in Files" page to remove the 'uncomment the users store' step since `statamic/statamic` now ships with an [empty `stores` array](https://github.com/statamic/statamic/blob/4.x/config/statamic/stache.php#L29).

Closes #910.
Closes statamic/cms#3795.