### PR TITLE
Nocache tag: Document the new `select` parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log
 # When in dev...
 /public/**/.meta
 .antlers.json
+content/collections/.obsidian

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ yarn-error.log
 # When in dev...
 /public/**/.meta
 .antlers.json
-content/collections/.obsidian

--- a/content/collections/tags/nocache.md
+++ b/content/collections/tags/nocache.md
@@ -182,7 +182,7 @@ Alternatively, you can use the `@auto` placeholder for Statamic to extract the v
 ```
 
 :::tip
-It's worth noting, the `nocache` tag won't be able to extract variables used inside if statements, PHP code or tags. You will need to explicitly define the variables you need in these cases.
+It's worth noting, the `nocache` tag won't be able to extract variables used inside partials or PHP files like custom tags. You will need to explicitly define the variables you need in these cases.
 :::
 
 You can also combine them to extract the variables from the template and add additional onces:

--- a/content/collections/tags/nocache.md
+++ b/content/collections/tags/nocache.md
@@ -166,6 +166,31 @@ Only the `title`'s change would be reflected, since the `reviews` value was reme
 <div class="movie"> Top Gun 60% Ratings </div>
 ```
 
+#### Performance
+Sometimes, you may notice the contents of the `nocache` taking a while to load. This is often caused by Statamic hydrating all of the variables from the context.
+
+To improve performance, you can explicitly select the variables you need:
+
+```
+{{ nocache select="this|that" }}
+```
+
+Alternatively, you can use the `@auto` placeholder for Statamic to extract the variables from the template (this is similar to the `@shallow` placeholder in the nav tag):
+
+```html
+{{ nocache select="@auto" }}
+```
+
+:::tip
+It's worth noting, the `nocache` tag won't be able to extract variables used inside if statements, PHP code or tags. You will need to explicitly define the variables you need in these cases.
+:::
+
+You can also combine them to extract the variables from the template and add additional onces:
+
+```
+{{ nocache select="@auto|this|that" }}
+```
+
 ## Full Measure Static Caching
 
 When using the `file` static cache driver (aka. "full measure") the pages will be stored as plain `html` files on your server.


### PR DESCRIPTION
**Note: This PR should be held until v4.39.0 has been merged.**

This pull request documents the new `select` parameter that's been added to the `{{ nocache }}` tag recently. 

Related: 
* https://github.com/statamic/cms/pull/8956 
* statamic/cms#9124