### PR TITLE
Tweak "Storing Users in a Database" doc

### DIFF
--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -58,9 +58,30 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
     ```cli
     php please auth:migration
     ```
-    - If you have existing file based users, edit the migration to change the `id` column to a `uuid`.
+    - If you're planning to import existing file based users, edit the migration to change the `id` & `user_id` columns to the `uuid` type.
         ```php
-        $table->uuid('id')->change();
+        Schema::table('users', function (Blueprint $table) {
+            $table->uuid('id')->change(); // [tl! ++] [tl! **]
+            $table->boolean('super')->default(false);
+            $table->string('avatar')->nullable();
+            $table->json('preferences')->nullable();
+            $table->timestamp('last_login')->nullable();
+            $table->string('password')->nullable()->change();
+        });
+
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');  // [tl! --] [tl! **]
+            $table->uuid('user_id');  // [tl! ++] [tl! **]
+            $table->string('role_id');
+        });
+
+        Schema::create('group_user', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');  // [tl! --] [tl! **]
+            $table->uuid('user_id');  // [tl! ++] [tl! **]
+            $table->string('group_id');
+        });
         ```
     - If you've customized your `user` blueprint, edit the migration so it includes those fields as columns. You can also create a new migration file by running `php artisan make:migration`. You'll have to manually edit the migration file to reflect your changes. Read up on [Laravel database migrations here](https://laravel.com/docs/10.x/migrations).
         ```php

--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -21,13 +21,23 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
 1. Ensure you have a [database configured](https://laravel.com/docs/database#configuration).
 1. In your user model, cast the preferences column to json.
     ```php
-    $casts = [
-        'preferences' => 'json', // [tl! ++]
-    ];
+    class User extends Authenticatable
+    {
+         protected $casts = [ // [tl! focus]
+            'preferences' => 'json', // [tl! ++] [tl! focus]
+        ]; // [tl! focus]
+
+         // ...
+    }
     ```
-1. If you plan to import existing file based users, you'll need to use UUIDs for the primary key. You can do this by using a trait on your user model:
+1. If you plan to import existing file based users, you'll need to use UUIDs for the primary key. You can do this by adding a trait to your user model:
     ```php
-    use \Illuminate\Database\Eloquent\Concerns\HasUuids; // [tl! ++]
+    class User extends Authenticatable
+    {
+        use \Illuminate\Database\Eloquent\Concerns\HasUuids; // [tl! ++] [tl! focus]
+
+        // ...
+    }
     ```
 1. In `config/statamic/users.php`, use the Eloquent repository.
     ```php


### PR DESCRIPTION
This PR makes some tweaks to the "Storing Users in a Database" page on the docs. It makes it a little bit clearer *where* the casts/use statement should sit in a User model (to clarify for those who don't know much PHP). 

It also updates the step around editing the migrations when using UUIDs for user IDs. When reproducing statamic/cms#9291, I noticed we documented changing the `id` column on the `users` table but not on the `role_user` and `group_user` tables where the change also needs to take place.

Closes statamic/cms#9291.