### PR TITLE
Document the `Site` facade

### DIFF
--- a/content/collections/repositories/site-repository.md
+++ b/content/collections/repositories/site-repository.md
@@ -27,7 +27,7 @@ use Statamic\Facades\Site;
 | `selected()` | Returns the site currently selected in the Control Panel |
 | `setSelected($handle)` | Sets the selected site. |
 | `default()` | Returns the "default site", which will be the first site in the `sites` config |
-| `authorized()` | Returns a collection of Site objects, where the user is authorized to view the site (see [Multisite Permissions](https://statamic.dev/multi-site#permissions)). |
+| `authorized()` | Returns a collection of Site objects, where the user is authorized to view the site (see [Multisite Permissions](/multi-site#permissions)). |
 | `hasMultiple()` | Returns a boolean indicating if multiple sites are configured. |
 | `setConfig($config)` | Accepts an array. Allows you to override the configured sites. |
 

--- a/content/collections/repositories/site-repository.md
+++ b/content/collections/repositories/site-repository.md
@@ -1,0 +1,44 @@
+---
+id: 668f4934-9dd9-4e5b-b24e-8fa6173336c2
+blueprint: repositories
+title: 'Site Repository'
+class: \Statamic\Facades\Site
+nav_title: 'Sites'
+related_entries:
+  - fb20f2e0-3881-43e6-8507-3308a18c54b0
+updated_by: 3a60f79d-8381-4def-a970-5df62f0f5d56
+updated_at: 1634259827
+---
+To work with the with Site Repository, use the following Facade:
+
+```php
+use Statamic\Facades\Site;
+```
+
+## Methods
+
+| Methods | Description |
+| ------- | ----------- |
+| `all()` | Get all Sites |
+| `get($handle)` | Get Site by handle |
+| `findByUrl($url)` | Get site by a given URL |
+| `current()` | Returns the current site, determined by the current page URL. |
+| `setCurrent($handle)` | Sets the current site. |
+| `selected()` | Returns the site currently selected in the Control Panel |
+| `setSelected($handle)` | Sets the selected site. |
+| `default()` | Returns the "default site", which will be the first site in the `sites` config |
+| `authorized()` | Returns a collection of Site objects, where the user is authorized to view the site (see [Multisite Permissions](https://statamic.dev/multi-site#permissions)). |
+| `hasMultiple()` | Returns a boolean indicating if multiple sites are configured. |
+| `setConfig($config)` | Accepts an array. Allows you to override the configured sites. |
+
+## Resolving the current site
+
+When you're using the `Site::current()` method, sometimes the current page URL will lead to the wrong site being returned (like when using Livewire). In this case, you can use the resolveCurrentUrlUsing to check against a different URL:
+
+```php
+// app/Providers/AppServiceProvider.php
+
+use Statamic\Facades\Site;
+
+Site:: resolveCurrentUrlUsing(fn () => Livewire::originalUrl());
+```

--- a/content/collections/repositories/site-repository.md
+++ b/content/collections/repositories/site-repository.md
@@ -40,5 +40,5 @@ When you're using the `Site::current()` method, sometimes the current page URL w
 
 use Statamic\Facades\Site;
 
-Site:: resolveCurrentUrlUsing(fn () => Livewire::originalUrl());
+Site::resolveCurrentUrlUsing(fn () => Livewire::originalUrl());
 ```


### PR DESCRIPTION
This PR adds documentation for the `Site` facade. I've added this page into the "Reference -> Repositories" section since we don't have a "Facades" section or similar.

Closes #1173.