### PR TITLE
Link added to the Laravel upgrade guide

### DIFF
--- a/content/collections/docs/upgrade-guide.md
+++ b/content/collections/docs/upgrade-guide.md
@@ -12,3 +12,4 @@ blueprint: page
 - [3.0 to 3.1](/upgrade-guide/3-0-to-3-1)
 - [2.x to 3.x](/upgrade-guide/v2-to-v3)
 - [Bard 1 to 2](/upgrade-guide/bard-v1-to-v2)
+- [Laravel 7 to 8](/upgrade-guide/laravel-7-to-8)


### PR DESCRIPTION
There’s a Laravel upgrade guide on Statamic.dev not listed on the upgrade guides page. It would be helpful to list it here.