### PR TITLE
Reflect Netlify support for PHP 8.2 and 8.3

### DIFF
--- a/content/collections/docs/netlify.md
+++ b/content/collections/docs/netlify.md
@@ -15,7 +15,7 @@ Deployments are triggered by committing changes to your Git repository. Alternat
 ## Prerequisites
 
 :::tip
-Netlify **only supports PHP <=8.1** and defaults to PHP 8.0. You can [specify the PHP version](https://docs.netlify.com/configure-builds/manage-dependencies/#php) using the `PHP_VERSION` environment variable.
+While Netlify supports PHP versions from 7.4 through 8.3, it defaults to PHP 8.0. You can [specify the PHP version](https://docs.netlify.com/configure-builds/manage-dependencies/#php) using the `PHP_VERSION` environment variable.
 :::
 
 - A [Netlify](https://netlify.com) account


### PR DESCRIPTION
After a LOT of [badgering](https://answers.netlify.com/t/php-8-2-support/98957) over the past six months as well as some support from @simonhamp [on Twitter](https://x.com/simonhamp/status/1741625727806554589?s=20), it looks like Netlify is **finally** supporting PHP 8.2 and 8.3. This PR updates the docs to reflect this change.