### PR TITLE
Recommend new `pro:enable` command instead

### DIFF
--- a/content/collections/tips/how-to-enable-statamic-pro.md
+++ b/content/collections/tips/how-to-enable-statamic-pro.md
@@ -5,10 +5,10 @@ title: 'How to Enable Statamic Pro'
 intro: 'A fresh Statamic install starts in Solo edition mode. Here''s how to enable Pro mode and unlock every feature Statamic has.'
 template: page
 ---
-A fresh Statamic install starts in Solo edition mode. You can enable Pro at any time in your `config/statamic/editions.php` file:
+A fresh Statamic install starts in Solo edition mode. You can enable Pro at any time by running:
 
-``` php
-'pro' => true,
+``` shell
+php please pro:enable
 ```
 
 Once you've opted in, many additional features become be available.

--- a/content/collections/tips/how-to-enable-statamic-pro.md
+++ b/content/collections/tips/how-to-enable-statamic-pro.md
@@ -11,6 +11,8 @@ A fresh Statamic install starts in Solo edition mode. You can enable Pro at any 
 php please pro:enable
 ```
 
+Instead of running the command, you can also set `pro` to `true` in `config/statamic/editions.php`.
+
 Once you've opted in, many additional features become be available.
 
 ## Trying Pro Mode {#trial-mode}


### PR DESCRIPTION
For https://github.com/statamic/cms/pull/9435, if that gets accepted

Should we maybe also add a note for older installations where this new `pro:enable` command doesn't exist?