### PR TITLE
Fix example directory structure on "Addons" page

### DIFF
--- a/content/collections/extending-docs/addons.md
+++ b/content/collections/extending-docs/addons.md
@@ -32,13 +32,13 @@ addons/
         src/
             ServiceProvider.php
         composer.json
-    app/
-    content/
-    config/
-    public/
-        index.php
-    resources
-    composer.json
+app/
+content/
+config/
+public/
+    index.php
+resources
+composer.json
 ```
 
 ``` json


### PR DESCRIPTION
This pull request fixes the example directory structure on the ["Addons"](https://statamic.dev.test/extending/addons#creating-an-addon) page.

The example currently makes it look like the app sits inside the `addons` directory, not that the `addons` directory is sitting alongside `app`/`resources`/etc.

## Before

![CleanShot 2024-02-15 at 11 59 02](https://github.com/statamic/docs/assets/19637309/8de0dcee-7c45-4aeb-81bc-2aa5b9b79081)

## After

![CleanShot 2024-02-15 at 11 58 39](https://github.com/statamic/docs/assets/19637309/96cafdd3-a1ff-4835-ac75-cc2a82dc5ad8)
