### PR TITLE
Add limit parameter to foreach tags

### DIFF
--- a/content/collections/tags/foreach.md
+++ b/content/collections/tags/foreach.md
@@ -14,6 +14,11 @@ parameters:
     type: string|array
     description: |
       The name of the array to loop over, or a reference to the array itself. See [dynamic variables](#dynamic-variables).
+  -
+    name: limit
+    type: int
+    description: |
+      Limits the number of items returned in the loop.
 stage: 4
 id: 34b03d03-a113-467f-a1c9-65bc6b446220
 ---


### PR DESCRIPTION
The "**limit**" parameter is found in the "**foreach**" tags  but does not appear in the documentation.

=> https://github.com/statamic/cms/blob/4.x/src/Tags/Iterate.php#L47