### PR TITLE
[4.x] Document hex_to_rgb modifier

### DIFF
--- a/content/collections/modifiers/hex_to_rgb.md
+++ b/content/collections/modifiers/hex_to_rgb.md
@@ -8,7 +8,7 @@ title: 'Hex To RGB'
 Converts a color from hex to RGB, the perfect match for the [color fieldtype](/fieldtypes/color).
 
 ```yaml
-color: #FF269E
+color: `#FF269E`
 ```
 
 ```

--- a/content/collections/modifiers/hex_to_rgb.md
+++ b/content/collections/modifiers/hex_to_rgb.md
@@ -4,7 +4,6 @@ blueprint: modifiers
 modifier_types:
   - utility
 title: 'Hex To RGB'
-duplicated_from: 2d555b32-e68c-4f9b-8570-f2e8d185989b
 ---
 Converts a color from hex to RGB, the perfect match for the [color fieldtype](/fieldtypes/color).
 

--- a/content/collections/modifiers/hex_to_rgb.md
+++ b/content/collections/modifiers/hex_to_rgb.md
@@ -1,0 +1,21 @@
+---
+id: 69000ef1-0a98-42a4-ba1a-0bab4c58ca7d
+blueprint: modifiers
+modifier_types:
+  - utility
+title: 'Hex To RGB'
+duplicated_from: 2d555b32-e68c-4f9b-8570-f2e8d185989b
+---
+Converts a color from hex to RGB, the perfect match for the [color fieldtype](/fieldtypes/color).
+
+```yaml
+color: #FF269E
+```
+
+```
+{{ color | hex_to_rgb }}
+```
+
+```html
+255, 38, 158
+```


### PR DESCRIPTION
This PR adds basic documentation for the hex_to_rgb modifier added in https://github.com/statamic/cms/pull/9582 closes #1257.