### PR TITLE
Fix Vercel Deploy Formatting

### DIFF
--- a/content/collections/docs/vercel.md
+++ b/content/collections/docs/vercel.md
@@ -17,7 +17,7 @@ Deployments are triggered by committing to Git and pushing to GitHub.
 #### Code for build.sh
 Add the following snippet to `build.sh` file to install PHP, Composer, and run the `ssg:generate` command:
 
-```
+```bash
 #!/bin/sh
 
 # Install PHP & WGET


### PR DESCRIPTION
Changes formatting of code block to `bash`. At the moment on the current docs, it displays as "antlers."

![CleanShot 2024-03-02 at 14 08 39@2x](https://github.com/statamic/docs/assets/39346975/f6682aae-09d2-4442-a9b2-dd0840e530a5)