### PR TITLE
Re-write the "Templating" section of the Form Fieldtype docs

### DIFF
--- a/content/collections/fieldtypes/form.md
+++ b/content/collections/fieldtypes/form.md
@@ -36,19 +36,12 @@ The Form fieldtype stores the `handle` of a single form as a string, or an array
 
 ## Templating
 
-The Form fieldtype uses [augmentation](/augmentation) to return Form instances.
+The Form fieldtype provides a few useful variables:
 
-```
-{{ form_field }}
-    {{ fields }}
-      <div class="p-2">
-          <label>{{ display }}</label>
-          <div class="p-1">{{ field }}</div>
-          {{ if error }}
-              <p class="text-gray-500">{{ error }}</p>
-          {{ /if }}
-      </div>
-  {{ /fields }}
-  <button type="submit">Submit</button>
-{{ /form_field }}
-```
+* `handle`
+* `title`
+* `fields`
+* `api_url`
+* `honeypot`
+
+You can use the [`{{ form:create }}`](/tags/form-create) tag to render a `<form>` on your page.


### PR DESCRIPTION
This pull request updates the "Templating" section of the Form fieldtype docs, to clarify how the tag should be used. It also directs people to the `{{ form:create }}` tag if they wish to render a form.