### PR TITLE
Minor bugfix to nav-breadcrumbs.md

### DIFF
--- a/content/collections/tags/nav-breadcrumbs.md
+++ b/content/collections/tags/nav-breadcrumbs.md
@@ -54,12 +54,12 @@ Breadcrumbs don't follow structures, they follow the current URL hierarchy.
 Here's an example of what breadcrumbs might look like, as well as a code example in use.
 
 <figure>
-    <div class="flex font-mono">
+    <div class="flex font-mono mx-4">
       <div class="mr-4">Home</div>
       <div class="mr-4">&rarr;</div>
       <div class="mr-4">Blog</div>
       <div class="mr-4">&rarr;</div>
-      <div class="mr-4 text-pink-hot font-bold">How to Dress Like David Hasselhoff</div>
+      <div class="text-pink-hot font-bold">How to Dress Like David Hasselhoff</div>
     </div>
     <figcaption>These crumbs are delicious.</figcaption>
 </figure>


### PR DESCRIPTION
Minor bugfix to example `figure` internal left margin

![Screenshot 2024-04-10 at 8 40 43 pm](https://github.com/statamic/docs/assets/4531017/25de009c-16b6-4fb5-b5c4-1e3a4faa5306)
