### PR TITLE
Update docs on querying entry statuses

### DIFF
--- a/content/collections/docs/4-to-5.md
+++ b/content/collections/docs/4-to-5.md
@@ -377,48 +377,52 @@ If you use this `{{ glide filename="" }}` parameter, you'll need to remove remov
 
 If you are hot-linking to any images rendered with manually set filenames in this way, you'll also need to correct those links.
 
-### Entry statuses can now only be queried using the `is`/`equals` condition
-**Affects any apps filtering entries by `status`. Either via the `{{ collection }}` tag, our PHP repositories, the REST API or the GraphQL API.**
+### Entries may now only be queried by a single status
+**Affects any apps or addons filtering entries by `status`.**
 
 Previously, when querying entries, you could use *any* condition to filter entries.
 
-However, in v5, as part of improvements to how statuses work behind the schenes, statuses can now only be filtered using the `is` / `equals` conditions.
+However, in v5, as part of improvements to how statuses work behind the schenes, statuses can now only be filtered using the `is` / `equals` conditions, and the `whereStatus` query method. Some examples:
 
+Collection tag:
 ```antlers
-{{ collection:blog status:is="published" }}
+{{ collection:blog status:in="published" }} {{# [tl! --] #}}
+{{ collection:blog status:is="published" }} {{# [tl! ++] #}}
 ```
 
+PHP:
 ```php
 Entry::query()
     ->where('collection', 'blog')
-    ->where('status', 'published')
+    ->where('status', 'published') // [tl! --]
+    ->whereStatus('published') // [tl! ++]
     ->get();
 ```
 
-```
-/api/collections/blog/entriesfilter[status]=published
+REST API:
+```php
+/api/collections/blog/entries?filter[status:in]=published // [tl! --]
+/api/collections/blog/entries?filter[status]=published // [tl! ++]
 ```
 
+GraphQL API:
 ```graphql
 {
     entries(
         collection: "blog"
         filter: {
-            status: { equals: "published" }
+            status: { in: "published" }         #[tl! --]
+            status: "published"                 #[tl! ++]
         }
     ) {
         data {
             title
-            status
-            excerpt
         }
     }
 }
 ```
 
-:::tip Note
-If you need to filter by multiple statuses at once, you will need to do multiple queries and merge the results.
-:::
+Let us know if you need to query by multiple statuses by opening a [GitHub issue](https://github.com/statamic/cms).
 
 ## Zero impact changes
 

--- a/content/collections/docs/4-to-5.md
+++ b/content/collections/docs/4-to-5.md
@@ -377,6 +377,60 @@ If you use this `{{ glide filename="" }}` parameter, you'll need to remove remov
 
 If you are hot-linking to any images rendered with manually set filenames in this way, you'll also need to correct those links.
 
+### Entry statuses can now only be queried using the `is`/`equals` condition
+**Affects any apps filtering entries by `status`. Either via the `{{ collection }}` tag, our PHP repositories, the REST API or the GraphQL API.**
+
+Previously, when querying entries, you could use any condition to filter entries.
+
+```antlers
+{{ collection:blog status:in="published|draft" }}
+```
+
+```php
+Entry::query()
+    ->where('collection', 'blog')
+    ->whereIn('status', ['published', 'draft'])
+    ->get();
+```
+
+However, in v5, as part of improvements to how statuses work behind the schenes, statuses can now only be filtered using the `is` / `equals` conditions.
+
+```antlers
+{{ collection:blog status:is="published" }}
+```
+
+```php
+Entry::query()
+    ->where('collection', 'blog')
+    ->where('status', 'published')
+    ->get();
+```
+
+```
+/api/collections/blog/entriesfilter[status]=published
+```
+
+```graphql
+{
+    entries(
+        collection: "blog"
+        filter: {
+            status: { equals: "published" }
+        }
+    ) {
+        data {
+            title
+            status
+            excerpt
+        }
+    }
+}
+```
+
+:::tip Note
+If you need to filter by multiple statuses at once, you will need to do multiple queries and merge the results.
+:::
+
 ## Zero impact changes
 
 These are items that you can completely ignore. They are suggestions on how to improve your code using newly added features.

--- a/content/collections/docs/4-to-5.md
+++ b/content/collections/docs/4-to-5.md
@@ -380,18 +380,7 @@ If you are hot-linking to any images rendered with manually set filenames in thi
 ### Entry statuses can now only be queried using the `is`/`equals` condition
 **Affects any apps filtering entries by `status`. Either via the `{{ collection }}` tag, our PHP repositories, the REST API or the GraphQL API.**
 
-Previously, when querying entries, you could use any condition to filter entries.
-
-```antlers
-{{ collection:blog status:in="published|draft" }}
-```
-
-```php
-Entry::query()
-    ->where('collection', 'blog')
-    ->whereIn('status', ['published', 'draft'])
-    ->get();
-```
+Previously, when querying entries, you could use *any* condition to filter entries.
 
 However, in v5, as part of improvements to how statuses work behind the schenes, statuses can now only be filtered using the `is` / `equals` conditions.
 

--- a/content/collections/tags/collection.md
+++ b/content/collections/tags/collection.md
@@ -214,14 +214,8 @@ There are several different ways to use this filtering parameter. They are expla
 By default, only `published` entries are included.  Entries can be queried against `draft`, `scheduled`, or `expired` status with [conditions](#conditions) on `status` like this:
 
 ```
-// Include draft entries
-{{ collection:blog status:in="published|draft" }}
-
-// Only include expired entries
-{{ collection:blog status:is="expired" }}
-
-// Exclude published entries
-{{ collection:blog status:not_in="published" }}
+// Only include published entries
+{{ collection:blog status:is="published" }}
 ```
 
 :::tip


### PR DESCRIPTION
This pull request adds a section to the "4 -> 5" upgrade guide around changes to querying entry statuses.

Related: https://github.com/statamic/cms/pull/9317