### PR TITLE
Install on Ubuntu add php-curl

### DIFF
--- a/content/collections/docs/ubuntu.md
+++ b/content/collections/docs/ubuntu.md
@@ -28,7 +28,7 @@ sudo apt-get upgrade
 ## Install PHP & Required Modules
 
 ``` shell
-sudo apt install php-common php-fpm php-json php-mbstring zip unzip php-zip php-cli php-xml php-tokenizer -y
+sudo apt install php-common php-fpm php-json php-mbstring zip unzip php-zip php-cli php-xml php-tokenizer php-curl -y
 ```
 
 ## Install Composer


### PR DESCRIPTION
I followed the documentation: https://statamic.dev/installing/ubuntu
but I got an error during the `composer install` step because `php-curl` was missing. Adding it fixed the issue.