### PR TITLE
[5.6.0] Document `depth` parameter on `flatten` modifier

### DIFF
--- a/content/collections/modifiers/flatten.md
+++ b/content/collections/modifiers/flatten.md
@@ -31,3 +31,20 @@ ingredients:
   - onion
   - chicken
 ```
+
+You can optionally pass a `depth` parameter to the `flatten` modifier, allowing you to specify how deeply nested arrays should be flattened.
+
+```yaml
+-
+  - garlic
+  - cumin
+  - ginger
+  - turmeric
+  - paprika
+  - curry powder
+-
+  - tomatoes
+  - onion
+-
+  - chicken
+```


### PR DESCRIPTION
PR: https://github.com/statamic/cms/pull/10187

Closes #1348.