### PR TITLE
Sort reserved words list alphabetically

### DIFF
--- a/content/collections/tips/reserved-words.md
+++ b/content/collections/tips/reserved-words.md
@@ -11,9 +11,11 @@ categories:
 This is the list of reserved words you shouldn't use as field names, in addition to the names of Statamic's [Tags](/tags) and [contextual variables](/variables).
 
 - `content_type`
+- `count`
 - `elseif`
 - `endif`
 - `endunless`
+- `hook`
 - `id`
 - `if`
 - `length`
@@ -23,7 +25,6 @@ This is the list of reserved words you shouldn't use as field names, in addition
 - `status`
 - `unless`
 - `value`
-- `count`
 
 :::warning
 Some of these _may_ work as field names in some circumstances, but can have unintended consequences, like overriding global data, behaviors, or creating issues with Vue components inside the Control Panel.

--- a/content/collections/tips/reserved-words.md
+++ b/content/collections/tips/reserved-words.md
@@ -15,7 +15,6 @@ This is the list of reserved words you shouldn't use as field names, in addition
 - `elseif`
 - `endif`
 - `endunless`
-- `hook`
 - `id`
 - `if`
 - `length`


### PR DESCRIPTION
Using `hook` as a field name throws `Too few arguments to function Statamic\Entries\Entry::hook()` errors when fetching collections via the API.

Also I've sorted the list alphabetically.