### PR TITLE
Edit docs for storing users in a database to place instructions in correct order

### DIFF
--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -134,10 +134,6 @@ You will need to run migrations to prepare your database for Statamic's user, pa
 2. Create and run the migrations.
 
     This will add some columns to the `users` table (like `super`, and `last_login`), create the `role_user` and `group_user` pivot tables, and create the `password_activations` table.
-   
-:::tip
-When using `sqlite` or `mysql` as your database driver, make sure to `composer require doctrine/dbal`. We change the `users` table in our auth migrations and therefore [require](https://laravel.com/docs/master/migrations#modifying-columns) the `doctrine/dbal` to run the migrations without errors.
-:::
 
     ``` shell
     php please auth:migration

--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -134,22 +134,22 @@ You will need to run migrations to prepare your database for Statamic's user, pa
 2. Create and run the migrations.
 
     This will add some columns to the `users` table (like `super`, and `last_login`), create the `role_user` and `group_user` pivot tables, and create the `password_activations` table.
+   
+:::tip
+When using `sqlite` or `mysql` as your database driver, make sure to `composer require doctrine/dbal`. We change the `users` table in our auth migrations and therefore [require](https://laravel.com/docs/master/migrations#modifying-columns) the `doctrine/dbal` to run the migrations without errors.
+:::
 
     ``` shell
     php please auth:migration
     php artisan migrate
     ```
-3. (optional) If you are using the Statamic forgot password form, add the following method to your User model
+4. (optional) If you are using the Statamic forgot password form, add the following method to your User model
     ```php
     public function sendPasswordResetNotification($token)
     {
         $this->notify(new \Statamic\Notifications\PasswordReset($token));
     }
     ```
-
-:::tip
-When using `sqlite` or `mysql` as your database driver, make sure to `composer require doctrine/dbal`. We change the `users` table in our auth migrations and therefore [require](https://laravel.com/docs/master/migrations#modifying-columns) the `doctrine/dbal` to run the migrations without errors.
-:::
 
 
 This assumes you are happy to use our opinionated setup. If you need something more custom you can [create your own user driver](/tips/storing-users-somewhere-custom).

--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -139,7 +139,7 @@ You will need to run migrations to prepare your database for Statamic's user, pa
     php please auth:migration
     php artisan migrate
     ```
-4. (optional) If you are using the Statamic forgot password form, add the following method to your User model
+4. Optional: If you are using the Statamic forgot password form, add the following method to your User model
     ```php
     public function sendPasswordResetNotification($token)
     {


### PR DESCRIPTION
In https://statamic.dev/tips/storing-users-in-a-database :

I suggest moving the tip about composer require doctrine/dbal to a position in the docs where it is most useful. 

Otherwise the reader works down all the instructions, and then finds this when it's too late!