### PR TITLE
Remove whereCollection and whereInCollection from docs

### DIFF
--- a/content/collections/repositories/entry-repository.md
+++ b/content/collections/repositories/entry-repository.md
@@ -25,8 +25,6 @@ use Statamic\Facades\Entry;
 | `findByUri($uri, $site)` | Get Entry by `uri`, optionally in a site |
 | `findOrFail($id)` | Get Entry by `id`. Throws an `EntryNotFoundException` when the entry cannot be found. |
 | `query()` | Query Builder |
-| `whereCollection($handle)` | Get all Entries in a `Collection` |
-| `whereInCollection([$handles])` | Get all Entries in an array of `Collections` |
 | `make()` | Makes a new entry instance |
 
 ## Querying


### PR DESCRIPTION
Methods are not available anymore and throw errors:

Call to undefined method Statamic\Stache\Query\EntryQueryBuilder::whereCollection()

Call to undefined method Statamic\Stache\Query\EntryQueryBuilder::whereInCollection()