### PR TITLE
Controllers: cascade entry content

### DIFF
--- a/content/collections/docs/controllers.md
+++ b/content/collections/docs/controllers.md
@@ -74,21 +74,22 @@ public function index()
 Now, `myview` will be injected into `mylayout`'s `template_content` variable.
 Anything provided to `with` (eg. `title`) will be available in both views.
 
-To make an entry's content directly available to your view, use the `cascadeContent` method:
+If you want to make an entry's content available in your view, you can use the `cascadeContent` method:
 
 ``` php
+// app/Http/Controllers/MySpecialController.php
+
 public function index()
 {
-    $myEntry = Entry::whereCollection('my_collection')
-                        ->where('slug', $slug)
-                        ->where('published', true)
-                        ->first();
+    $entry = Entry::whereCollection('pages')
+        ->where('slug', 'special-page')
+        ->where('published', true)
+        ->first();
 
     return (new \Statamic\View\View)
         ->template('myview')
-        ->layout('mylayout')
-        ->with(['title' => 'Example Title']);
-        ->cascadeContent($myEntry);
+        ->layout('mylayout');
+        ->cascadeContent($entry);
 }
 ```
 

--- a/content/collections/docs/controllers.md
+++ b/content/collections/docs/controllers.md
@@ -74,6 +74,24 @@ public function index()
 Now, `myview` will be injected into `mylayout`'s `template_content` variable.
 Anything provided to `with` (eg. `title`) will be available in both views.
 
+To make an entry's content directly available to your view, use the `cascadeContent` method:
+
+``` php
+public function index()
+{
+    $myEntry = Entry::whereCollection('my_collection')
+                        ->where('slug', $slug)
+                        ->where('published', true)
+                        ->first();
+
+    return (new \Statamic\View\View)
+        ->template('myview')
+        ->layout('mylayout')
+        ->with(['title' => 'Example Title']);
+        ->cascadeContent($myEntry);
+}
+```
+
 ## Related Reading
 
 - [Laravel Controllers][laravel-controllers]


### PR DESCRIPTION
This PR updates the Controllers page to include an explanation of how to cascade an entry's content into an Antlers view with the `cascadeContent` method.