### PR TITLE
Fix typos in variables/edit_url.md

### DIFF
--- a/content/collections/variables/edit_url.md
+++ b/content/collections/variables/edit_url.md
@@ -5,7 +5,7 @@ types:
   - content
 title: 'Edit Url'
 ---
-Get the URL to edit a the current page or entry in the Control Panel, if there is one (for example, there is no `edit_url` for a template route).
+Get the URL to edit the current page or entry in the Control Panel, if there is one (for example, there is no `edit_url` for a template route).
 
 The user will need to login and have permissions, so it's probably best if used in conjunction with [permissions checks](/tags/user-can).
 


### PR DESCRIPTION
# Problem

There's a small typo on the [variables/edit_url](https://statamic.dev/variables/edit_url) page

# Solution

This PR fixes the typo