### PR TITLE
Fix small typos in views.md

### DIFF
--- a/content/collections/docs/views.md
+++ b/content/collections/docs/views.md
@@ -56,7 +56,7 @@ Layouts usually contain `<head></head>` markup, global header, navigation, foote
 </html>
 ```
 
-An entry can control the layout its rendered with by setting the `layout` system variable.
+An entry can control the layout it's rendered with by setting the `layout` system variable.
 
 ``` yaml
 # Use /resources/views/rss.antlers.html


### PR DESCRIPTION
# Problem

There's a small typo on the [views](https://statamic.dev/views) page

# Solution

This PR fixes the typo

# Notes

Thanks for accepting these PRs 🙂

[Don't forget](https://www.grammarly.com/blog/its-vs-its/) that **its** is always a possessive adjective and **it's** is always a contraction for "it is" (or "it has")