### PR TITLE
Revert "Update static-caching.md"

### DIFF
--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -389,7 +389,13 @@ return [
                     ]
                 ]
             ],
-            'navigation' => 'all'
+            'navigation' => [
+                'links' => [
+                    'urls' => [
+                        '/*'
+                    ]
+                ]
+            ]
         ]
     ]
 ];
@@ -400,7 +406,7 @@ return [
 - “when an entry in the blog collection is saved, we should invalidate the /blog page, any pages beginning with /blog/category/, and the home page.”
 - “when a term in the tags taxonomy is saved, we should invalidate those same pages”
 - “when the settings global set is saved, we invalidate all urls”
-- “when any of the navigations are saved, we invalidate all urls”
+- “when the links navigation is saved, we invalidate all urls”
 
 You may add as many collections and taxonomies as you need.
 


### PR DESCRIPTION
This pull request reverts #1396, where the docs were updated to suggest that you use `all` as an invalidation rule for a specific type of content.

I blindly merged it, presuming it'd work. But shortly after, I checked the code and it seems like you can only use `all` in the context of `'rules' => 'all'`.

Whoopsie!