### PR TITLE
Fix typos in conditional-fields.md

### DIFF
--- a/content/collections/docs/conditional-fields.md
+++ b/content/collections/docs/conditional-fields.md
@@ -207,7 +207,7 @@ if:
 
 ## Field Context
 
-By default, conditions are performed against values in current level of `fields` in your blueprint.  If you need access to values outside of this context (eg. if you are in a replicator, trying to compare against fields outside of the replicator), you can access root VueX store values by prepending your field with `root`:
+By default, conditions are performed against values in the current level of `fields` in your blueprint.  If you need access to values outside of this context (eg. if you are in a replicator, trying to compare against fields outside of the replicator), you can access root VueX store values by prepending your field with `root`:
 
 ```yaml
 if:
@@ -274,7 +274,7 @@ Statamic.$conditions.add('...', ({ root, store, storeName }) => {
 
 If you wish to conditionally apply validation to conditionally shown fields, we recommend using the `sometimes` [Laravel validation rule](https://laravel.com/docs/validation#validating-when-present).
 
-```
+```yaml
 -
   handle: online_event
   field:


### PR DESCRIPTION
# Problem

There are small typos on the [conditional-fields](https://statamic.dev/conditional-fields) page

# Solution

This PR fixes the typos

# Notes

  * Apologies if I am mistaken, but a grammatical article appears to be missing in a sentence.
  * A block of YAML is missing the `yaml` part at the top of the code block declaration.