### PR TITLE
Fix small typo in live-preview.md

### DIFF
--- a/content/collections/docs/live-preview.md
+++ b/content/collections/docs/live-preview.md
@@ -99,7 +99,7 @@ preview_targets:
     url: /blog
 ```
 
-You may use entry's variables in the URL, just like defining a route.
+You may use the entry's variables in the URL, just like defining a route.
 
 If you don't define any targets, it will use the entry's URL.
 


### PR DESCRIPTION
# Problem

There's a small typo on the [live-preview](https://statamic.dev/live-preview) page

# Solution

This PR fixes the typo