### PR TITLE
Update docker install guide to not need a custom docker-compose.yml

### DIFF
--- a/content/collections/docs/docker.md
+++ b/content/collections/docs/docker.md
@@ -23,45 +23,13 @@ If you don't already have Docker installed, head to [docker.com/get-started](htt
 
 ## Installing Laravel
 
-Follow the install instructions for creating a fresh Laravel app from [their documentation](https://laravel.com/docs/9.x#your-first-laravel-project).
+Follow the install instructions for creating a fresh Laravel app from [their documentation](https://laravel.com/docs/11.x#creating-a-laravel-project).
 
-On MacOS, run the following command, changing `example-app` to anything you want.
+Install Laravel Sail into your new Laravel app with no additional services, unless you want to get fancy and use MySQL with Statamic (yes, you can do that).
 
-```shell
-curl -s "https://laravel.build/example-app" | bash
-```
-
-## Statamic Docker-Composer File
-
-Unless you plan to get fancy and use MySQL with Statamic (yes, you can do that), replace the default `docker-compose.yml` file with this one to keep your overhead low.
-
-``` yaml
-# For more information: https://laravel.com/docs/sail
-version: '3'
-services:
-    laravel.test:
-        build:
-            context: ./vendor/laravel/sail/runtimes/8.2
-            dockerfile: Dockerfile
-            args:
-                WWWGROUP: '${WWWGROUP}'
-        image: sail-8.2/app
-        extra_hosts:
-            - 'host.docker.internal:host-gateway'
-        ports:
-            - '${APP_PORT:-80}:80'
-        environment:
-            WWWUSER: '${WWWUSER}'
-            LARAVEL_SAIL: 1
-            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
-            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
-        volumes:
-            - '.:/var/www/html'
-        networks:
-            - sail
-networks:
-    sail:
-        driver: bridge
+``` shell
+composer require laravel/sail --dev
+php artisan sail:install --with=none
 ```
 
 ## Starting and Stopping Sail


### PR DESCRIPTION
Removes the need to maintain a custom `docker-compose.yml` file in the docs.

The suggested `docker-compose.yml` file is currently out of date as it is missing the Vite ports and also uses php 8.2 rather than 8.3 which is what the latest Laravel build script would use.

In addition the current suggested build script for Mac OSX users sets all the defaults in the Laravel config to use MySQL so when switching to the version without MySQL there are additional configuration steps needed to get it working which aren't currently in the documentation.

So this change should make it easier for most users to get up and running if they just follow the standard new Laravel project instructions which defaults to sqlite.