### PR TITLE
Add warning about using existing tag names for taxonomies

### DIFF
--- a/content/collections/docs/taxonomies.md
+++ b/content/collections/docs/taxonomies.md
@@ -21,6 +21,11 @@ Each entry in a taxonomy is often called a **term**.
 Watch how to set up your first Taxonomy
 :::
 
+> [!CAUTION]
+> Avoid giving your taxonomy a name that is already used for a Statamic system [tag](tags).
+> Using an existing tag name will create complications when you come to reference your taxonomy and its terms in views.
+> For example, if you call your taxonomy 'Section', that will conflict with the system tag {{ section }} in your templates.
+
 ## Collections
 
 Each collection defines which taxonomies are part of its content model in their blueprint. Thus, taxonomies and their terms are connected to entries _through_ the collection in a strict relationship. Once you attach a taxonomy to a collection, the fields, variables, and routes are added automatically.


### PR DESCRIPTION
At the moment there is no disambiguation between tags for taxonomies and tags for system tags within views.

So a taxonomy called 'Section' can't be referenced as ```{{ section }} <li> ... </li> {{ /section }}``` in views because it conflicts with the existing Statamic system tag {{ section }}.

There is a way to disambiguate between variables and tags, but not between types of tags.

I've submitted an idea to provide this disambiguation: https://github.com/statamic/ideas/issues/1195

But in the meantime, I suggest adding this warning to the taxonomy page to avoid people getting in a pickle.