### PR TITLE
Make taxonomies routing docs clearer

### DIFF
--- a/content/collections/docs/taxonomies.md
+++ b/content/collections/docs/taxonomies.md
@@ -45,12 +45,12 @@ URLs use slugs with dashes, and views use handles with underscores.
 
 - **Global Taxonomy Details**
   - Display the details of the taxonomy, so you can list the terms.
-  - Accessible at `/{taxonomy-slug}` (eg. `/product-tags`)
-  - The `{taxonomy_handle}/index` view will be used (eg. `product_tags/index.antlers.html`)
+  - Accessible at `/{taxonomy-slug}` (eg. `/tags`)
+  - The `{taxonomy_handle}/index` view will be used (eg. `tags/index.antlers.html`)
 - **Global Term details**
   - Display the details of the term, so you can list the entries.
-  - Accessible at `/{taxonomy-slug}/{term-slug}` (eg. `/product-tags/t-shirts`)
-  - The `{taxonomy_handle}/show` view will be used. (eg. `product_tags/show.antlers.html`)
+  - Accessible at `/{taxonomy-slug}/{term-slug}` (eg. `/tags/t-shirts`)
+  - The `{taxonomy_handle}/show` view will be used. (eg. `tags/show.antlers.html`)
 
 For each taxonomy [assigned to a collection](#collections) you will also get these routes:
 
@@ -58,12 +58,12 @@ For each taxonomy [assigned to a collection](#collections) you will also get the
   - Display the details of the taxonomy, so you can list the terms.
   - Only terms that have been used in entries in the collection will be displayed.
   - Accessible at `/{collection-url}/{taxonomy-slug}` (eg. `/products/tags`)
-  - The `{collection_handle}/{taxonomy_handle}/index` view will be used (eg. `blog/tags/index.antlers.html`)
+  - The `{collection_handle}/{taxonomy_handle}/index` view will be used (eg. `products/tags/index.antlers.html`)
 - **Collection Term details**
   - Display the details of the term, so you can list the entries.
   - Only entries that exist in the collection will be displayed.
-  - Accessible at `/{collection-url}/{taxonomy slug}/{term slug}` (eg. `/blog/tags/retrowave`)
-  - The `{collection_handle}/{taxonomy}/show` view will be used. (eg. `blog/tags/show.antlers.html`)
+  - Accessible at `/{collection-url}/{taxonomy-slug}/{term-slug}` (eg. `/products/tags/t-shirts`)
+  - The `{collection_handle}/{taxonomy_handle}/show` view will be used. (eg. `products/tags/show.antlers.html`)
 
 ## Term Values and Slugs
 


### PR DESCRIPTION
This PR aims to make the docs a little clearer by streamlining the examples.