### PR TITLE
[5.15] `value` is no longer a reserved word

### DIFF
--- a/content/collections/tips/reserved-words.md
+++ b/content/collections/tips/reserved-words.md
@@ -23,7 +23,6 @@ This is the list of reserved words you shouldn't use as field names, in addition
 - `save`
 - `status`
 - `unless`
-- `value`
 
 :::warning
 Some of these _may_ work as field names in some circumstances, but can have unintended consequences, like overriding global data, behaviors, or creating issues with Vue components inside the Control Panel.


### PR DESCRIPTION
Goes alongside statamic/cms#10462.