### PR TITLE
Fix typo in values modifier documentation

### DIFF
--- a/content/collections/modifiers/values.md
+++ b/content/collections/modifiers/values.md
@@ -6,7 +6,7 @@ modifier_types:
   - array
   - utility
 ---
-Retrieves just the keys from the given array.
+Retrieves just the values from the given array.
 
 ```yaml
 the_team:


### PR DESCRIPTION
This PR fixes a small typo or copy/paste error on values modifier documentation. 