### PR TITLE
Add note about users deleting entries in other sites

### DIFF
--- a/content/collections/tips/localizing-entries.md
+++ b/content/collections/tips/localizing-entries.md
@@ -100,7 +100,7 @@ If you want to delete an origin, you need to make a decision on how to handle an
 ![](/img/tips/delete-localization-modal.png)
 
 :::note
-When the user doesn't have access to the other sites an entry is localized in, the only option will be to detach the localizations.
+When a user doesn't have access to the sites an entry is localized into, deleting it will detach the localizations.
 :::
 
 ### Option 1: Delete

--- a/content/collections/tips/localizing-entries.md
+++ b/content/collections/tips/localizing-entries.md
@@ -99,6 +99,10 @@ If you want to delete an origin, you need to make a decision on how to handle an
 
 ![](/img/tips/delete-localization-modal.png)
 
+:::note
+When the user doesn't have access to the other sites an entry is localized in, the only option will be to detach the localizations.
+:::
+
 ### Option 1: Delete
 
 If you no longer need the localized version, then you can choose to just delete them.


### PR DESCRIPTION
This pull request adds a note mentioning the fact that if a user doesn't have access to the other sites an entry is localized in, then the only option will be to detach those localizations.

Goes alongside statamic/cms#10587.