### PR TITLE
Expand explanations of disambiguating tags and variables

### DIFF
--- a/content/collections/docs/antlers.md
+++ b/content/collections/docs/antlers.md
@@ -328,6 +328,8 @@ As your templates grow and increase in complexity, you _may_ find yourself unsur
 {{ $content }}
 ```
 
+This includes variables that Statamic creates for you, such as the objects of your collections or taxonomies. For example, a taxonomy called 'Section' could be disambiguated from Statamic's own Section tag by referencing it as ```{{ $section }}```.
+
 ### Modifiers
 
 Modifiers change the output of an Antlers variable. They are used inside any expression and are separated by a pipe character `|`.

--- a/content/collections/docs/taxonomies.md
+++ b/content/collections/docs/taxonomies.md
@@ -132,6 +132,11 @@ When the collection can be inferred, the `url` and `permalink` values will inclu
 - ✅ Looping through terms in a taxonomy tag pair, using the collection parameter.
 - ❌ Looping through terms in a taxonomy tag pair, without specifying a collection.
 
+:::tip
+The tags based on your taxonomy names, eg {{ tags }}, can be disambiguated from other Statamic tags by prefixing with $. 
+For example, if you have a taxonomy called 'Section', its tag would clash with Statamic's own {{ section }} tag. So you can reference it with {{ $section }}.
+:::
+
 ### Listings and Indexes
 
 When on a [taxonomy route](#routing), you can list the terms by using a `terms` tag pair. For example:


### PR DESCRIPTION
Adding some clarity that the collections and taxonomy objects are included in the description of disambiguating tags and variables.

This was a minor stumbling block for me in learning Statamic frontend. @jasonvarga explained it to me, so I'm contributing this based on my learning so others don't make the same wrong assumption as me.