### PR TITLE
Update PHP version in Vercel environment to support Statamic 5

### DIFF
--- a/content/collections/docs/vercel.md
+++ b/content/collections/docs/vercel.md
@@ -22,7 +22,7 @@ Add the following snippet to `build.sh` file to install PHP, Composer, and run t
 
 # Install PHP & WGET
 yum install -y amazon-linux-extras
-amazon-linux-extras enable php8.1
+amazon-linux-extras enable php8.2
 yum clean metadata
 yum install php php-{common,curl,mbstring,gd,gettext,bcmath,json,xml,fpm,intl,zip,imap}
 yum install wget


### PR DESCRIPTION
Setting the PHP version to 8.2. If the PHP version is set to 8.1, Statamic 4 gets installed instead of Statamic 5.

```
Cannot use statamic/statamic's latest version v5.0.7 as it requires php ^8.2 which is not satisfied by your platform.
Installing statamic/statamic (v4.0.6)
  - Downloading statamic/statamic (v4.0.6)
  - Installing statamic/statamic (v4.0.6): Extracting archive
```