### PR TITLE
Use the latest version of Laravel in docs links

### DIFF
--- a/content/collections/docs/account-api-sites.md
+++ b/content/collections/docs/account-api-sites.md
@@ -26,7 +26,7 @@ Http::acceptJson()
   ->post('https://statamic.com/api/v1/sites', $payload);
 ```
 
-_*For more info, read more about [headers](https://laravel.com/docs/8.x/http-client#headers) and [bearer tokens](https://laravel.com/docs/8.x/http-client#bearer-tokens) in Laravel._
+_*For more info, read more about [headers](https://laravel.com/docs/11.x/http-client#headers) and [bearer tokens](https://laravel.com/docs/11.x/http-client#bearer-tokens) in Laravel._
 
 ## Endpoints
 

--- a/content/collections/docs/blueprints.md
+++ b/content/collections/docs/blueprints.md
@@ -215,7 +215,7 @@ If you omit the `prefix` you won't be able to import them more than once at the 
 
 Fields can have various validation rules applied to them, enforcing the need for content creators to fill them out in a specific way before saving or publishing.
 
-While configuring a field, switch to the **Validation** tab where you can choose from [any built in Laravel rule](https://laravel.com/docs/8.x/validation#available-validation-rules).
+While configuring a field, switch to the **Validation** tab where you can choose from [any built in Laravel rule](https://laravel.com/docs/11.x/validation#available-validation-rules).
 
 On top of any Laravel validation rules, there are some Statamic-specific goodies (like usage with conditional fields, Grids, Bards, or Replicators) that are explained on our [dedicated validation documentation](/validation).
 

--- a/content/collections/docs/content-queries.md
+++ b/content/collections/docs/content-queries.md
@@ -13,7 +13,7 @@ These methods will work no matter which driver you're using — flat files, Eloq
 [Learn how Statamic can use different storage methods!](/extending/repositories)
 
 :::tip
-While Statamic's Query builder is very similar to [Laravel's Query Builder](https://laravel.com/docs/8.x/queries), they are **completely separate implementations**.
+While Statamic's Query builder is very similar to [Laravel's Query Builder](https://laravel.com/docs/11.x/queries), they are **completely separate implementations**.
 
 What follows is complete documentation on all available methods. If you need a method available in Laravel that we don't currently support, feel free to open a [feature request](https://github.com/statamic/ideas) or better yet, a [Pull Request](https://github.com/statamic/cms)!
 :::
@@ -498,7 +498,7 @@ Entry::query()->paginate(15);
 This will return an instance of `Illuminate\Pagination\LengthAwarePaginator` that you can use to assemble the pagination style of your choice.
 
 :::tip
-You can [learn more about the LengthAwarePaginator](https://laravel.com/docs/10.x/pagination#paginator-instance-methods)in the Laravel docs.
+You can [learn more about the LengthAwarePaginator](https://laravel.com/docs/11.x/pagination#paginator-instance-methods)in the Laravel docs.
 :::
 
 ## Chunking
@@ -514,7 +514,7 @@ Entry::query()->chunk(25, function($entries) {
 ```
 
 :::tip
-You can [learn more about chunking query results](https://laravel.com/docs/10.x/queries#chunking-results) in the Laravel docs.
+You can [learn more about chunking query results](https://laravel.com/docs/11.x/queries#chunking-results) in the Laravel docs.
 :::
 
 ## Lazy Streaming
@@ -528,7 +528,7 @@ Entry::query()->lazy(100)
 ```
 
 :::tip
-You can learn more about [lazily streaming query results](https://laravel.com/docs/10.x/queries#streaming-results-lazily) and [LazyCollections](https://laravel.com/docs/10.x/collections#lazy-collections) in the Laravel docs.
+You can learn more about [lazily streaming query results](https://laravel.com/docs/11.x/queries#streaming-results-lazily) and [LazyCollections](https://laravel.com/docs/11.x/collections#lazy-collections) in the Laravel docs.
 :::
 
 ## Repository Classes

--- a/content/collections/docs/docker.md
+++ b/content/collections/docs/docker.md
@@ -7,7 +7,7 @@ intro: Docker is an open source project that streamlines the deployment of an ap
 parent: ab08f409-8bbe-4ede-b421-d05777d292f7
 ---
 ## Overview
-[Laravel Sail](https://laravel.com/docs/9.x/sail) is a light-weight command-line interface for interacting with Laravel's default Docker development environment. Sail provides a great starting point for building Laravel applications without requiring prior Docker experience, and is a perfect fit for Statamic with a few tweaks.
+[Laravel Sail](https://laravel.com/docs/11.x/sail) is a light-weight command-line interface for interacting with Laravel's default Docker development environment. Sail provides a great starting point for building Laravel applications without requiring prior Docker experience, and is a perfect fit for Statamic with a few tweaks.
 
 At its heart, Sail is a `docker-compose.yml` file and script that is stored at the root of your project. The sail script provides a CLI with convenient methods for interacting with the Docker containers defined by the `docker-compose.yml` file.
 
@@ -75,4 +75,4 @@ Keep in mind that  commands need to be run inside Sail.
 
 ## Learn more about Laravel Sail
 
-The [Laravel Sail docs](https://laravel.com/docs/9.x/sail) cover a lot more of what you can do with Sail. Check them out!
+The [Laravel Sail docs](https://laravel.com/docs/11.x/sail) cover a lot more of what you can do with Sail. Check them out!

--- a/content/collections/docs/fields.md
+++ b/content/collections/docs/fields.md
@@ -111,7 +111,7 @@ Learn more about configuring Statamic for [multi-site](/multi-site) projects.
 
 You may provide translations for the field UI (such as the display text, instructions, select option labels, etc). This allows content editors to display the Control Panel in their preferred language, regardless of whether it's used in a multi-site setup.
 
-Field UI strings are run through [Laravel's translations](https://laravel.com/docs/10.x/localization) feature.
+Field UI strings are run through [Laravel's translations](https://laravel.com/docs/11.x/localization) feature.
 
 For example, you may have a field defined like this:
 

--- a/content/collections/docs/forms.md
+++ b/content/collections/docs/forms.md
@@ -519,7 +519,7 @@ axios.post(form.action, new FormData(form))
 ```
 
 ## Precognition
-Statamic supports using [Laravel Precognition](https://laravel.com/docs/10.x/precognition) in forms.
+Statamic supports using [Laravel Precognition](https://laravel.com/docs/11.x/precognition) in forms.
 
 Here is a basic example that uses Alpine.js for the Precognition validation, and a regular form submission. This is a starting point that you may customize as needed. For instance, you might prefer to use AJAX to submit the form.
 

--- a/content/collections/docs/frontend.md
+++ b/content/collections/docs/frontend.md
@@ -50,7 +50,7 @@ You could do so many different things, like:
 
 - Use our [GraphQL](/graphql) integration and build your frontend with [Gatsby.js](https://www.gatsbyjs.com/)
 - Use our [REST API](/rest-api) and build a single page application with [Vue.js](https://vuejs.org) or [React](https://reactjs.org/)
-- Use [Laravel Blade](https://laravel.com/docs/9.x/blade) and some controllers and write your own routes.
+- Use [Laravel Blade](https://laravel.com/docs/11.x/blade) and some controllers and write your own routes.
 
 It's up to you.
 

--- a/content/collections/docs/requirements.md
+++ b/content/collections/docs/requirements.md
@@ -1,6 +1,6 @@
 ---
 title: Requirements
-intro: Statamic is a modern PHP application built as a [Laravel](https://laravel.com) package, which carries with it the same [server requirements](https://laravel.com/docs/9.x/deployment#server-requirements) as Laravel itself. To manipulate images (resize, crop, etc), you will also need the GD Library or ImageMagick installed on your server.
+intro: Statamic is a modern PHP application built as a [Laravel](https://laravel.com) package, which carries with it the same [server requirements](https://laravel.com/docs/11.x/deployment#server-requirements) as Laravel itself. To manipulate images (resize, crop, etc), you will also need the GD Library or ImageMagick installed on your server.
 template: page
 id: 792644d2-8bd2-421d-a080-e0be7fca125c
 blueprint: page
@@ -44,7 +44,7 @@ You can even share your sites publicly using local tunnels. We use it ourselves 
 
 ### Windows: WAMP
 
-[Laragon][laragon] and [WAMP][wamp] are both good choice for those of the Windows persuasion. You may also want to checkout [Laravel Sail](https://laravel.com/docs/8.x/sail), which works well with Statamic or the [Valet for Windows port][valet-windows].
+[Laragon][laragon] and [WAMP][wamp] are both good choice for those of the Windows persuasion. You may also want to checkout [Laravel Sail](https://laravel.com/docs/11.x/sail), which works well with Statamic or the [Valet for Windows port][valet-windows].
 
 
 

--- a/content/collections/docs/sites-api.md
+++ b/content/collections/docs/sites-api.md
@@ -27,7 +27,7 @@ Http::acceptJson()
   ->post('https://statamic.com/v1/api/sites, $payload);
 ```
 
-_*For more info, read more about [headers](https://laravel.com/docs/8.x/http-client#headers) and [bearer tokens](https://laravel.com/docs/8.x/http-client#bearer-tokens) in Laravel._
+_*For more info, read more about [headers](https://laravel.com/docs/11.x/http-client#headers) and [bearer tokens](https://laravel.com/docs/11.x/http-client#bearer-tokens) in Laravel._
 
 ## Endpoints
 

--- a/content/collections/docs/users.md
+++ b/content/collections/docs/users.md
@@ -160,7 +160,7 @@ public function boot()
 }
 ```
 
-Consult the [Laravel documentation](https://laravel.com/docs/8.x/validation#validating-passwords) to see all the available methods for customizing the password rule.
+Consult the [Laravel documentation](https://laravel.com/docs/11.x/validation#validating-passwords) to see all the available methods for customizing the password rule.
 
 ## Storing User Records {#storage}
 

--- a/content/collections/docs/validation.md
+++ b/content/collections/docs/validation.md
@@ -144,7 +144,7 @@ If you want to override the field that is being validated (e.g. in Livewire Form
 ## Custom Rules
 
 You may use custom validation rules via Laravel's `Rule` objects.  
-[Documentation on those are here](https://laravel.com/docs/10.x/validation#using-rule-objects).
+[Documentation on those are here](https://laravel.com/docs/11.x/validation#using-rule-objects).
 
 To references those from your field, you can add them to your `validation` array as if you were writing PHP:
 
@@ -162,4 +162,4 @@ validate:
   - 'new App\Rules\AnotherRule(''with argument'')'
 ```
 
-[laravel-validation]: https://laravel.com/docs/10.x/validation#available-validation-rules
+[laravel-validation]: https://laravel.com/docs/11.x/validation#available-validation-rules

--- a/content/collections/extending-docs/testing-in-addons.md
+++ b/content/collections/extending-docs/testing-in-addons.md
@@ -66,7 +66,7 @@ class ExampleTest extends TestCase
 }
 ```
 
-For more information on writing tests, please review the [Laravel Testing Documentation](https://laravel.com/docs/10.x/testing).
+For more information on writing tests, please review the [Laravel Testing Documentation](https://laravel.com/docs/11.x/testing).
 
 ### The Stache
 

--- a/content/collections/tags/cache.md
+++ b/content/collections/tags/cache.md
@@ -15,7 +15,7 @@ parameters:
   -
     name: tags
     type: string|array
-    description: 'The [cache tags](https://laravel.com/docs/8.x/cache#cache-tags) this section will be using, if you''d like to invalidate this pair programmatically. If you use this, do not also use `key`.'
+    description: 'The [cache tags](https://laravel.com/docs/9.x/cache#cache-tags) this section will be using, if you''d like to invalidate this pair programmatically. If you use this, do not also use `key`.'
   -
     name: scope
     type: 'string'

--- a/content/collections/tags/vite-content.md
+++ b/content/collections/tags/vite-content.md
@@ -38,4 +38,4 @@ If you need to, you can also specify a custom build directory.
 {{ vite src="resources/css/tailwind.css|resources/js/site.js" directory="bundle" }}
 ```
 
-When using these options, please make sure to also adjust your `vite.config.js` file. More about advanced customization can be found in [Laravel's Vite docs](https://laravel.com/docs/9.x/vite#advanced-customization).
+When using these options, please make sure to also adjust your `vite.config.js` file. More about advanced customization can be found in [Laravel's Vite docs](https://laravel.com/docs/11.x/vite#advanced-customization).

--- a/content/collections/tags/vite.md
+++ b/content/collections/tags/vite.md
@@ -49,7 +49,7 @@ Additionally, you can set custom locations for the build directory and hot file.
 ```
 {{ vite src="resources/css/tailwind.css|resources/js/site.js" directory="bundle" hot="storage/vite.hot" }}
 ```
-When using these options, please make sure to also adjust your `vite.config.js` file. More about advanced customization can be found in [Laravel's Vite docs](https://laravel.com/docs/9.x/vite#advanced-customization).
+When using these options, please make sure to also adjust your `vite.config.js` file. More about advanced customization can be found in [Laravel's Vite docs](https://laravel.com/docs/11.x/vite#advanced-customization).
 
 ## Processing Static Assets With Vite
 

--- a/content/collections/tips/building-your-own-entries-repository.md
+++ b/content/collections/tips/building-your-own-entries-repository.md
@@ -1,7 +1,7 @@
 ---
 id: 853b6690-c1fc-46bc-b865-e61a33d14563
 title: 'Building your own Entries Repository'
-intro: 'Statamic stores your content in "flat files" by default, but its data layer is completely driver-driven – giving you the ability to store content **anywhere**. In this article we''ll show you how to store entries in a database with [Laravel Eloquent](https://laravel.com/docs/8.x/eloquent).'
+intro: 'Statamic stores your content in "flat files" by default, but its data layer is completely driver-driven – giving you the ability to store content **anywhere**. In this article we''ll show you how to store entries in a database with [Laravel Eloquent](https://laravel.com/docs/11.x/eloquent).'
 template: page
 categories:
   - development
@@ -244,7 +244,7 @@ public function register()
 
 ## The Model
 
-Since we're using Eloquent, we need a [model](https://laravel.com/docs/8.x/eloquent#defining-models). Let's set one up.
+Since we're using Eloquent, we need a [model](https://laravel.com/docs/11.x/eloquent#generating-model-classes). Let's set one up.
 
 ``` php
 <?php

--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -86,7 +86,7 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
             $table->string('group_id');
         });
         ```
-    - If you've customized your `user` blueprint, edit the migration so it includes those fields as columns. You can also create a new migration file by running `php artisan make:migration`. You'll have to manually edit the migration file to reflect your changes. Read up on [Laravel database migrations here](https://laravel.com/docs/10.x/migrations).
+    - If you've customized your `user` blueprint, edit the migration so it includes those fields as columns. You can also create a new migration file by running `php artisan make:migration`. You'll have to manually edit the migration file to reflect your changes. Read up on [Laravel database migrations here](https://laravel.com/docs/11.x/migrations).
         ```php
         $table->string('some_field');
         ```


### PR DESCRIPTION
I also manually verified that each link works. Some left as before due to the section no longer existing in the newer version.

Because Laravel 10 is [EOL](https://endoflife.date/laravel) in 4 months, I replaced its links to 11 as well.