### PR TITLE
Update search.md

### DIFF
--- a/content/collections/docs/search.md
+++ b/content/collections/docs/search.md
@@ -203,7 +203,7 @@ class MyTransformer
 Whenever you save an item in the Control Panel it will automatically update any appropriate indexes. If you edit content by hand, you can tell Statamic to scan for new and updated records via the command line.
 
 ``` shell
-# Select which indexes to update from a prompt
+# Select which indexes to update
 php please search:update
 
 # Update a specific index

--- a/content/collections/docs/search.md
+++ b/content/collections/docs/search.md
@@ -203,11 +203,14 @@ class MyTransformer
 Whenever you save an item in the Control Panel it will automatically update any appropriate indexes. If you edit content by hand, you can tell Statamic to scan for new and updated records via the command line.
 
 ``` shell
-# Update all indexes
+# Select which indexes to update from a prompt
 php please search:update
 
 # Update a specific index
 php please search:update name
+
+# Update all indexes
+php please search:update --all
 ```
 
 ### Connecting Indexes


### PR DESCRIPTION
Adds documentation for the `--all` option. Also corrects the fact that `search:update` does in fact not update all indexes but will show the user a prompt from which they can select which indexes to update. All is also an option in the prompt.