### PR TITLE
Specify Algolia client version

### DIFF
--- a/content/collections/docs/search.md
+++ b/content/collections/docs/search.md
@@ -361,7 +361,7 @@ ALGOLIA_SECRET=your-algolia-admin-key
 ```
 
 ``` shell
-composer require algolia/algoliasearch-client-php
+composer require algolia/algoliasearch-client-php:^3.4
 ```
 
 Statamic will automatically create and sync your indexes as you create and modify entries once you kick off the initial index creation by running the command `php please search:update`.


### PR DESCRIPTION
The Algolia driver does not currently work with version 4 of the Algolia client package (results in a `Class "Algolia\AlgoliaSearch\SearchClient" not found` error), but if you follow the current docs that's what gets installed.

This PR updates the docs with the latest supported version.