### PR TITLE
Document new `$parent` (and updated `$root`) syntax for field conditions

### DIFF
--- a/content/collections/docs/conditional-fields.md
+++ b/content/collections/docs/conditional-fields.md
@@ -207,11 +207,18 @@ if:
 
 ## Field Context
 
-By default, conditions are performed against values in the current level of `fields` in your blueprint.  If you need access to values outside of this context (eg. if you are in a replicator, trying to compare against fields outside of the replicator), you can access root VueX store values by prepending your field with `root`:
+By default, conditions are performed against values in the current level of `fields` in your blueprint.  If you need access to values outside of this context (eg. if you are in a replicator, trying to compare against fields outside of the replicator), you can access parent field values by prepending your field with `$parent`:
 
 ```yaml
 if:
-  root.favorite_foods: includes bacon
+  $parent.favorite_foods: includes bacon
+```
+
+You can also access values at the top-level of your blueprint with `$root`:
+
+```yaml
+if:
+  $root.favorite_foods: includes bacon
 ```
 
 ## Custom Logic


### PR DESCRIPTION
This PR documents new `$parent` (and updated `$root`) syntax for field conditions, introduced in https://github.com/statamic/cms/pull/9385.

![CleanShot 2024-10-21 at 13 56 10](https://github.com/user-attachments/assets/a0a57c5d-bc73-4ddd-a877-cb3c6824736b)

Note: The old `root.` syntax (without dollar sign) is still backwards compatible, but `$root.` is the new recommended way going forward.
