### PR TITLE
Fix "Get a User Group" example

### DIFF
--- a/content/collections/repositories/user-group-repository.md
+++ b/content/collections/repositories/user-group-repository.md
@@ -29,7 +29,7 @@ use Statamic\Facades\UserGroup;
 #### Get a User Group
 
 ``` php
-UserGroup::find('admin')->get();
+UserGroup::find('admin');
 ```
 
 #### Get all users in a group


### PR DESCRIPTION
The example for Get a User Group isn't correct, and returns the following error:
`Too few arguments to function Statamic\Auth\UserGroup::get()`

It should just be `User::find('admin');`