### PR TITLE
Correct form permissions in docs for "view" and "delete" actions

### DIFF
--- a/content/collections/docs/users.md
+++ b/content/collections/docs/users.md
@@ -101,8 +101,8 @@ In turn, **roles** are attached directly to individual users or [user groups](#u
 | &nbsp;&nbsp;↳ Edit roles | `edit roles` |
 | &nbsp;&nbsp;↳ Impersonate users | `impersonate users` |
 | Configure forms | `configure forms` |
-| View form submissions | `view {form} submissions` |
-| &nbsp;&nbsp;↳ Delete form submissions | `delete {form} submissions` |
+| View form submissions | `view {form} form submissions` |
+| &nbsp;&nbsp;↳ Delete form submissions | `delete {form} form submissions` |
 
 ### Author Permissions
 


### PR DESCRIPTION
The permissions "view {form} submissions" and "delete {form} submissions" were incorrectly referenced in the Statamic documentation. The correct permissions should be "view {form} form submissions" and "delete {form} form submissions".

This fix aligns the documentation with the actual permissions defined in the Statamic CorePermissions class, ensuring clarity and accuracy for developers managing form submissions.

References:
- Statamic CorePermissions class: [view](https://github.com/statamic/cms/blob/58b912f504d6853dbcb629b211aa0a63167f0262/src/Auth/CorePermissions.php#L207)
- Statamic CorePermissions class: [delete](https://github.com/statamic/cms/blob/58b912f504d6853dbcb629b211aa0a63167f0262/src/Auth/CorePermissions.php#L205)