### PR TITLE
Document support for event listener auto-registration from typehinted `__invoke` methods

### DIFF
--- a/content/collections/extending-docs/addons.md
+++ b/content/collections/extending-docs/addons.md
@@ -443,7 +443,7 @@ return view('custom::foo');
 ::: tip
 Statamic v5.33.0 introduced the concept of "autoloading" for event listeners.
 
-As long as your event listener lives in `src/Listeners` and the event is typehinted in the listener's `handle` method, they will be automatically registered by Statamic, without you needing to register them manually.
+As long as your event listener lives in `src/Listeners` and the event is typehinted in the listener's `handle` or `__invoke` method, they will be automatically registered by Statamic, without you needing to register them manually.
 
 Subscribers will also be autoloaded, as long as they live in `src/Subscribers`.
 

--- a/content/collections/extending-docs/addons.md
+++ b/content/collections/extending-docs/addons.md
@@ -441,7 +441,7 @@ return view('custom::foo');
 ## Events
 
 ::: tip
-Statamic v5.33.0 introduced the concept of "autoloading" for event listeners.
+Statamic v5.35.0 introduced the concept of "autoloading" for event listeners.
 
 As long as your event listener lives in `src/Listeners` and the event is typehinted in the listener's `handle` or `__invoke` method, they will be automatically registered by Statamic, without you needing to register them manually.
 


### PR DESCRIPTION
Whoopsie, I merged #1519 before its associated Core PR has been released. 🤦‍♂️

I've reverted that PR on `master` and opened this PR which'll replace it. It also changes the version mentioned in the docs to v5.35.0, which includes some fixes for autoloading event listeners.