### PR TITLE
Document new form tags. 

### DIFF
--- a/content/collections/extending-docs/hooks.md
+++ b/content/collections/extending-docs/hooks.md
@@ -71,6 +71,21 @@ Triggered after the tag has been initialized. The payload is `null`.
 Triggered just after completing the query.
 The payload will either be an `EntryCollection` or a `Paginator`, depending on whether the `paginate` parameter was used.
 
+### Form tag: `attrs`
+Triggered when building the opening form tag. The payload is an array containing two properties:
+- 'attrs' - an array containing the currently calculated list of attributes for the opening &lt;form&gt; tag. Modifications to this array will affect the rendered form tag - e.g. it can be used to add attributes to the form tag.
+- 'data' - the data assembled about the form (config, blueprint, sections etc.)
+
+### Form tag: `after-open`
+Triggered immediately after the opening form tag. The payload is an array containing two properties:
+- 'html' - A string containing the rendered markup of the form so far. Modifications to this string will affect the final rendered markup.
+- 'data' - the data assembled about the form (config, blueprint, sections etc.)
+
+### Form tag: `before-open`
+Triggered immediately before the closing form tag. The payload is an array containing two properties:
+- 'html' - A string containing the rendered markup of the form so far. Modifications to this string will affect the final rendered markup.
+- 'data' - the data assembled about the form (config, blueprint, sections etc.)
+
 ### Augmentation: `augmented`
 Triggered when a new augmented instance is made.
 The payload will be the object being augmented (eg. `Entry` / `Term`).


### PR DESCRIPTION
This PR adds documentation for the three new form tag hooks introduced in https://github.com/statamic/cms/pull/11010 and fixes #1516.

There doesn't seem to be any obvious "order" to the existing listing, so I've just added these after the Collection tag, however if you'd like me to re-order the existing items alphabetically or similar, happy to update this PR to do that as well, e.g.

- All tags
- Augmentation
- Bard items
- Collection
- Entry index query
- Form
- Static cache warming