### PR TITLE
Update supported Statamic versions.

### DIFF
--- a/content/collections/docs/release-schedule-support-policy.md
+++ b/content/collections/docs/release-schedule-support-policy.md
@@ -31,7 +31,7 @@ Statamic and its other first-party packages follow [Semantic Versioning](https:/
          <td>Mar 2023</td>
          <td>Sep 2023</td>
       </tr>
-      <tr class="bg-gray-lightest text-black/60">
+      <tr class="bg-red text-[#ffc9bf]">
          <td class="font-bold">3.4*</td>
          <td>8-9</td>
          <td>7.4-8.1</td>
@@ -39,7 +39,7 @@ Statamic and its other first-party packages follow [Semantic Versioning](https:/
          <td>Jan 2023</td>
          <td>Jul 2024</td>
       </tr>
-      <tr class="bg-white">
+      <tr class="bg-red text-[#ffc9bf]">
          <td class="font-bold">4</td>
          <td>9-10</td>
          <td>8.0-8.3</td>


### PR DESCRIPTION
The [Release Schedule & Support Policy](https://statamic.dev/release-schedule-support-policy#versioning-scheme) shows outdated information regarding supported versions. This PR applies a red background to the version where support has ended (v3.4 and v4).