### PR TITLE
Undocument cache tagging

### DIFF
--- a/content/collections/tags/cache.md
+++ b/content/collections/tags/cache.md
@@ -13,10 +13,6 @@ parameters:
     type: string
     description: 'The cache key to be used, if you''d like to manually invalidate this tag pair programmatically.'
   -
-    name: tags
-    type: string|array
-    description: 'The [cache tags](https://laravel.com/docs/9.x/cache#cache-tags) this section will be using, if you''d like to invalidate this pair programmatically. If you use this, do not also use `key`.'
-  -
     name: scope
     type: 'string'
     description: 'Sets the [cache scope](#scope). Three possible values: `site`, `page` or `user`. Has no effect when using the `key` parameter.'
@@ -164,37 +160,6 @@ class EventServiceProvider
 
 :::warning
 Invalidating by `key` won't work if you're using tags. In that case, you should invalidate by flushing the tag.
-:::
-
-### Tag
-
-By specifying `tags`, you can invalidate it programmatically. You must be using a cache driver that supports [tags](https://laravel.com/docs/8.x/cache#cache-tags), like Redis or Memcached.
-
-::tabs
-
-::tab antlers
-```antlers
-{{ cache tags="stocks|home" }} ... {{ /cache }}
-{{ cache tags="home" }} ... {{ /cache }}
-{{ cache tags="stocks" }} ... {{ /cache }}
-```
-::tab blade
-```blade
-<statamic:cache tags="stocks|home"> ... </statamic:cache>
-<statamic:cache tags="home"> ... </statamic:cache>
-<statamic:cache tags="stocks"> ... </statamic:cache>
-```
-::
-
-Similar to invalidating by a key as explained above, you can flush all keys that use the tags.
-
-```php
-Cache::tags('home')->flush(); // invalidates first and second pair
-Cache::tags('stocks')->flush(); // invalidates first and third pair
-```
-
-:::warning
-Don't use the `key` and `tags` parameters together.
 :::
 
 ### Cache clear


### PR DESCRIPTION
This pull request removes reference to Laravel's cache tagging functionality in our `{{ cache }}` tag, since Laravel now discourages the use of it.

It's no longer included in the Laravel docs, see https://github.com/laravel/docs/commit/63dde39470588ab1ad39cea9a592f0838ca5ad47.

There's no comment from the Laravel team on that commit but Taylor discussed it briefly during a Laracon AU Q&A and discourages people from using it.