### PR TITLE
UX Improvements

### DIFF
--- a/resources/js/searchHotKeys.js
+++ b/resources/js/searchHotKeys.js
@@ -2,6 +2,39 @@ function isAppleDevice() {
     return /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
 }
 
+function dismissSearchModal() {
+    const element = document.querySelector('.docsearch-modal-container');
+
+    if (! element) {
+        return;
+    }
+
+    const clickEvent = new MouseEvent('mousedown', {
+        bubbles: true,
+        cancelable: true,
+        view: window
+    });
+
+    element.dispatchEvent(clickEvent);
+}
+
+document.addEventListener('click', function(event) {
+    if (
+        event.target.closest('.docsearch-modal-search-hits-item') &&
+        event.target.closest('a')
+    ) {
+        if (event.ctrlKey || (isAppleDevice() && event.metaKey)) {
+            return;
+        }
+
+        if (! document.body.classList.contains('docsearch--active')) {
+            return;
+        }
+
+        dismissSearchModal();
+    }
+});
+
 if (isAppleDevice()) {
     window.addEventListener('keydown', function (e) {
         if (! e.metaKey) {
@@ -11,7 +44,6 @@ if (isAppleDevice()) {
         if (e.key.toLocaleLowerCase() !== 'k') {
             return;
         }
-
         document.getElementsByClassName('docsearch-btn')[0].click();
     });
 }


### PR DESCRIPTION
* Cleans up markup making its way to the search results modal, which can cause broken images/etc. or strange line wrapping
* Dismiss modal if the search result is a section on the current page (while preserving cmd/ctrl+click behavior)