### PR TITLE
Prevent default when pressing search hotkeys

### DIFF
--- a/resources/js/searchHotKeys.js
+++ b/resources/js/searchHotKeys.js
@@ -44,6 +44,8 @@ if (isAppleDevice()) {
         if (e.key.toLocaleLowerCase() !== 'k') {
             return;
         }
+        
         document.getElementsByClassName('docsearch-btn')[0].click();
+        e.preventDefault();
     });
 }


### PR DESCRIPTION
Prevent the default action when pressing ``cmd + k``. Within Firefox, this focuses the URL bar which is an unwanted side effect that should not happen. With this change, it focuses the search bar of the docs as intended.