### PR TITLE
Fix Replacer interface class in docs

### DIFF
--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -708,7 +708,7 @@ When a page is being statically cached on the first request, or loaded on subseq
 
 Statamic includes two replacers out of the box. One will replace [CSRF tokens](#csrf-tokens), the other will handle [nocache](/tags/nocache) tag usages.
 
-A replacer is a class that implements a `Statamic\StaticCaching\NoCache\Replacer` interface. You will be passed responses to the appropriate methods where you can adjust them as necessary.
+A replacer is a class that implements a `Statamic\StaticCaching\Replacer` interface. You will be passed responses to the appropriate methods where you can adjust them as necessary.
 
 You can then enable your class by adding it to `config/statamic/static_caching.php`:
 


### PR DESCRIPTION
I think the class referenced in the docs for Replacers shouldn't be the `NoCache` replacer it should be `Statamic\StaticCaching\Replacer` instead.