### PR TITLE
chore: spelling

### DIFF
--- a/content/collections/docs/caching.md
+++ b/content/collections/docs/caching.md
@@ -25,7 +25,7 @@ php please stache:warm
 php please stache:refresh
 ```
 
-The are settings you can configure to improve the performance of the stache, just like with a relational database. [Learn more about the Stache](/stache) and it's various settings.
+There are settings you can configure to improve the performance of the stache, just like with a relational database. [Learn more about the Stache](/stache) and it's various settings.
 
 :::tip
 **You cannot disable the stache** &mdash; it is critical architecture.


### PR DESCRIPTION
Simple spelling. "There are settings" instead of "The are settings"