### PR TITLE
Minor dark mode fix in search.css

### DIFF
--- a/resources/css/search.css
+++ b/resources/css/search.css
@@ -82,7 +82,7 @@ html[data-theme='dark'] {
 }
 
 .docsearch-modal-search-hits-item-title {
-    @apply text-black font-semibold;
+    @apply font-semibold;
 }
 
 .docsearch-modal-search-hits-item-text {


### PR DESCRIPTION
If I remove the `text-black` class from the style overrides it prevents a conflict with the dark mode styles.

Before:

![386996136-ff7eb692-bfe4-4059-95e8-9d0d1f81f991](https://github.com/user-attachments/assets/1cee8a45-4a8d-43c1-ab5a-02b8a7231b3b)

After:

![Google Chrome - 2024-11-29--17-50-42@2x](https://github.com/user-attachments/assets/82f741ee-e1bc-419d-be2a-1bcda11f7319)
![Google Chrome - 2024-11-29--17-51-10@2x](https://github.com/user-attachments/assets/e794c924-454d-485f-8ec2-1578e6beed74)

Fixes #1551.