### PR TITLE
add width variable for fields

### DIFF
--- a/content/collections/tags/form-create.md
+++ b/content/collections/tags/form-create.md
@@ -255,6 +255,8 @@ Each item in the `fields` array contains the following data configurable in the 
 | `old` | array | Contains user input from an unsuccessful submission |
 | `instructions` | string | User-friendly instructions label |
 | `validate` | array | Contains an array of validation rules |
+| `width` | string | Width of the field assigned in the blueprint |
+
 
 ### Pre-rendered Field HTML
 


### PR DESCRIPTION
Using Statamic 5.40 and discovered `width` was available, which is important if you want to create a form that accurately honors the field widths assigned in the form blueprint.