### PR TITLE
Fix Mangled Headings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "statamic/cms": "^4.0",
         "statamic/ssg": "^2.0",
         "torchlight/torchlight-commonmark": "^0.5.5",
-        "stillat/documentation-search": "^1.2.0"
+        "stillat/documentation-search": "^1.2.1"
     },
     "require-dev": {
         "beyondcode/laravel-dump-server": "^1.7",


### PR DESCRIPTION
Bumps the min. version of the underlying search provider. The previous version was skipping headings if they did not contain leading content, but contained content inside nested headings:

```

## A heading

### A sub heading

The "A heading" would be skipped.

```

This was causing some search phrases like `templating` to act strangely when building up the parent headings