### PR TITLE
Update partial docs to include named slots

### DIFF
--- a/content/collections/tags/partial.md
+++ b/content/collections/tags/partial.md
@@ -192,7 +192,8 @@ The solution is to use the partial tag as a pair. Everything inside will be pass
 </div>
 ```
 
-You could also name your slots by appending `:name`.
+You can also name your slots using the `name` parameter.
+
 
 ## Conditional Rendering
 

--- a/content/collections/tags/partial.md
+++ b/content/collections/tags/partial.md
@@ -192,6 +192,8 @@ The solution is to use the partial tag as a pair. Everything inside will be pass
 </div>
 ```
 
+You could also name your slots by appending `:name`.
+
 ## Conditional Rendering
 
 You can render a partial only if a condition is met.


### PR DESCRIPTION
Added a one-liner for named slots, should be mentioned here. Don't know about Blade syntax though.

Maybe integrate it into the existing code examples by using `slot` and named slots together.