### PR TITLE
Fix: Assets repositories docs links

### DIFF
--- a/content/collections/repositories/asset-container-repository.md
+++ b/content/collections/repositories/asset-container-repository.md
@@ -27,7 +27,7 @@ use Statamic\Facades\AssetContainer;
 | `find($id)` | Get AssetContainer by `id` |
 | `findByHandle($handle)` | Get AssetContainer by `handle` |
 | `findOrFail($id)` | Get AssetContainer by `id`. Throws an `AssetContainerNotFoundException` when the asset container cannot be found. |
-| `queryAssets()` | Query Builder for the AssetContainer's [Assets](#assets) |
+| `queryAssets()` | Query Builder for the AssetContainer's [Assets](/repositories/asset-repository) |
 | `make()` | Makes a new AssetContainer instance |
 
 :::tip

--- a/content/collections/repositories/asset-repository.md
+++ b/content/collections/repositories/asset-repository.md
@@ -25,7 +25,7 @@ use Statamic\Facades\Asset;
 | `findByUrl($url)` | Get Asset by `url` |
 | `findOrFail($filename)` | Get Asset by `filename`. Throws an `AssetNotFoundException` when the asset cannot be found. |
 | `query()` | Query Builder |
-| `whereContainer($container)` | Find Assets by [AssetContainer](#asset-container) |
+| `whereContainer($container)` | Find Assets by [AssetContainer](/repositories/asset-container-repository) |
 | `whereFolder($folder)` | Find Assets in a filesystem folder |
 | `make()` | Makes a new `Asset` instance |
 


### PR DESCRIPTION
Links for `AssetsContainer` and `Assets` in these two pages were wrong.