### PR TITLE
Fixed incorrect example syntax in docs

### DIFF
--- a/content/collections/extending-docs/dictionaries.md
+++ b/content/collections/extending-docs/dictionaries.md
@@ -68,11 +68,11 @@ protected function getItems(): array
 By default, the `value` and `label` keys will be used. However, you may remap them:
 
 ```php
+protected string $valueKey = 'abbr';
+protected string $labelKey = 'name';
+
 protected function getItems(): array
 {
-    protected string $valueKey = 'abbr';
-    protected string $labelKey = 'name';
-    
     return [
         ['name' => 'Alabama', 'abbr' => 'AL', 'capital' => 'Montgomery'],
         // ...


### PR DESCRIPTION
Corrected the syntax, properties are top level and can't be set inside a method.