### PR TITLE
Added optional cache-control header to static config

### DIFF
--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -160,6 +160,8 @@ location / {
 }
 
 location @static {
+    # Allow the browser (and a proxy) to cache static pages, Laravel wil overwrite it with "no-cache, private" by default if index.php needs to be hit.
+    # add_header Cache-Control "max-age=120, stale-while-revalidate=3600";
     try_files /static${uri}_$args.html $uri $uri/ /index.php?$args;
 }
 

--- a/content/collections/docs/ubuntu.md
+++ b/content/collections/docs/ubuntu.md
@@ -148,6 +148,8 @@ server {
     }
 
     location @static {
+        # Allow the browser (and a proxy) to cache static pages, Laravel wil overwrite it with "no-cache, private" by default if index.php needs to be hit.
+        # add_header Cache-Control "max-age=120, stale-while-revalidate=3600";
         try_files /static${uri}_$args.html $uri $uri/ /index.php?$args;
     }
 


### PR DESCRIPTION
Since we're statically serving these files anyways we can instruct the browser and a proxy (like cloudflare) to cache these files (in the examples 2 minutes with an hour to revalidate before it must serve directly from the server)

Note: Cloudflare will by default not cache pages ever, a cache rule can be created to respect the cache-control header