### PR TITLE
Update zero-downtime-deployments.md

### DIFF
--- a/content/collections/tips/zero-downtime-deployments.md
+++ b/content/collections/tips/zero-downtime-deployments.md
@@ -88,7 +88,7 @@ cd {{ release }}
 git init
 git remote add origin git@github.com:your/remote-repository.git
 git fetch
-git branch --track master origin/master
+git branch --track main origin/main
 git reset HEAD
 ```
 


### PR DESCRIPTION
Fixes outdated default branch name. I know it's a small thing, but I wasted a few minutes after copying and pasting the snippet myself. I think it's worth removing that friction for other people trying Statamic in the future.

[Context](https://github.com/github/renaming)