### PR TITLE
FIX: missing text color weight

### DIFF
--- a/content/collections/docs/quick-start-guide.md
+++ b/content/collections/docs/quick-start-guide.md
@@ -422,7 +422,7 @@ Open up your layout file and drop in this nav snippet, right after the open body
 // resources/views/layout.antlers.html
 // ...
 
-<nav class="bg-black text-xs uppercase text-green text-center flex items-center justify-center space-x-4">
+<nav class="bg-black text-xs uppercase text-green-500 text-center flex items-center justify-center space-x-4">
     {{ nav from="pages" include_home="true" }}
         <a href="{{ url }}" class="p-2 block hover:text-yellow-200">{{ title }}</a>
     {{ /nav  }}


### PR DESCRIPTION
Followed the quick start guide and was confused for a sec why my nav items were not showing: there is a small bug in the example code (missing tailwind text color weight), this fixes it.