### PR TITLE
fix: broken link in footer

### DIFF
--- a/resources/views/partials/footer.antlers.html
+++ b/resources/views/partials/footer.antlers.html
@@ -46,7 +46,7 @@
                 <ul class="space-y-2 text-sm">
                     <li><a href="https://statamic.com/support">Support Center</a></li>
                     <li><a href="https://statamic.com/partners">Partners</a></li>
-                    <li><a href="https://statamic.com/partners/how-to-join">Become a Partner</a></li>
+                    <li><a href="https://statamic.com/partners/join">Become a Partner</a></li>
                 </ul>
             </div>
             <div class="w-1/2 md:w-2/3 lg:w-auto pb-12">


### PR DESCRIPTION
See [this link](https://statamic.dev/#:~:text=Partners-,Become%20a%20Partner,-Search) in the footer
Should be https://statamic.com/partners/join instead of https://statamic.com/partners/how-to-join 