### PR TITLE
Fixed missing comma in example on where.md

### DIFF
--- a/content/collections/modifiers/where.md
+++ b/content/collections/modifiers/where.md
@@ -54,7 +54,7 @@ You can also pass an operator to the modifier, so you can do checks like "where 
 
 ```
 <h2>I hate...</h2>
-{{ games | where('feeling', '!=' 'love') }}
+{{ games | where('feeling', '!=', 'love') }}
   {{ title }}<br>
 {{ /games }}
 ```


### PR DESCRIPTION
Passing operators to the where modifier must be comma-separated from the value.