### PR TITLE
Update quick-start-guide.md nav sample code to prefix `from` attribute with a colon

### DIFF
--- a/content/collections/docs/quick-start-guide.md
+++ b/content/collections/docs/quick-start-guide.md
@@ -423,9 +423,9 @@ Open up your layout file and drop in this nav snippet, right after the open body
 // ...
 
 <nav class="bg-black text-xs uppercase text-green-500 text-center flex items-center justify-center space-x-4">
-    {{ nav from="pages" include_home="true" }}
+    {{ nav:collection:pages include_home="true" }}
         <a href="{{ url }}" class="p-2 block hover:text-yellow-200">{{ title }}</a>
-    {{ /nav  }}
+    {{ /nav:collection:pages  }}
 </nav>
 ```
 


### PR DESCRIPTION
Running through the quick start guide, I ran into an issue with using the current docs sample code for the navigation with
`{{ nav from="pages" include_home="true" }}` without the colon, would result in only 1 navigation item being displayed that is the current page.
![2025-03-25_07-04](https://github.com/user-attachments/assets/ae7f5937-60fe-44bf-86a2-17502f6be7fd)

Looking at the docs for the nav tag, it shows that the collections is referenced using `nav:collection:pages` instead of with the `from`
```
{{ nav:collection:pages include_home="true"}}
    <a href="{{ url }}" class="p-2 block hover:text-yellow-200">{{ title }}</a>
{{ /nav:collection:pages }}
```
