### PR TITLE
Minor fix blade tag {{ current_url }}

### DIFF
--- a/content/collections/variables/current_url.md
+++ b/content/collections/variables/current_url.md
@@ -15,7 +15,7 @@ The current URL.
 ```
 ::tab blade
 ```blade
-{{ $current_uri }}
+{{ $current_url }}
 ```
 ::
 


### PR DESCRIPTION
Fixing blade tag (uri -> url)

Looks like this was copied from the {{ current_url }} tag and didn't get changed.