### PR TITLE
Fixes docs referencing migrating users from flat-file to database

### DIFF
--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -74,15 +74,15 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
 
         Schema::create('role_user', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id');  // [tl! --] [tl! **]
-            $table->uuid('user_id');  // [tl! ++] [tl! **]
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();  // [tl! --] [tl! **]
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();  // [tl! ++] [tl! **]
             $table->string('role_id');
         });
 
         Schema::create('group_user', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('user_id');  // [tl! --] [tl! **]
-            $table->uuid('user_id');  // [tl! ++] [tl! **]
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();  // [tl! --] [tl! **]
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();  // [tl! ++] [tl! **]
             $table->string('group_id');
         });
         ```

--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -75,6 +75,7 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
         Schema::create('role_user', function (Blueprint $table) {
             $table->increments('id');
             $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();  // [tl! --] [tl! **]
+            $table->uuid('user_id');  // [tl! ++] [tl! **]
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();  // [tl! ++] [tl! **]
             $table->string('role_id');
         });
@@ -82,6 +83,7 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
         Schema::create('group_user', function (Blueprint $table) {
             $table->increments('id');
             $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();  // [tl! --] [tl! **]
+            $table->uuid('user_id');  // [tl! ++] [tl! **]
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();  // [tl! ++] [tl! **]
             $table->string('group_id');
         });


### PR DESCRIPTION
The database model for user roles and groups was updated in [this commit](https://github.com/statamic/cms/commit/96aa7eaa9db0545c2f60cc3042bfeffe4e397472).

The current documentation instructions for adjusting the migration to use UUIDs instead of incrementing IDs is outdated compared to the migration generated by `php please auth:migration`