### PR TITLE
Static-caching: .htaccess snippet: Removed </Ifmodule> as there was no start-mention of this..

### DIFF
--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -126,7 +126,6 @@ RewriteRule ^ index.php [L]
 RewriteCond %{DOCUMENT_ROOT}/static/%{REQUEST_URI}_%{QUERY_STRING}\.html -s
 RewriteCond %{REQUEST_METHOD} GET
 RewriteRule .* static/%{REQUEST_URI}_%{QUERY_STRING}\.html [L,T=text/html]
-</IfModule>
 ```
 
 :::tip

--- a/content/collections/docs/static-caching.md
+++ b/content/collections/docs/static-caching.md
@@ -852,7 +852,7 @@ If you need to output a CSRF token in another place while using full measure, yo
 
 ## Custom cache store
 
-Static caching leverages [Laravel's application cache](https://laravel.com/docs/cache) to store mappings of the URLs to the filenames. To ensure proper invalidation of changes to your content, Statamic uses a cache store _outside_ of the default one. Otherwise, running the `artisan cache:clear` command can lead invalidation to fail.
+Static caching leverages [Laravel's application cache](https://laravel.com/docs/cache) to store mappings of the URLs to the filenames. To ensure proper invalidation of changes to your content, Statamic uses a cache store _outside_ of the default one. Otherwise, running the `php artisan cache:clear` command can lead invalidation to fail.
 
 The cache store can be customized in `config/cache.php`.
 
@@ -863,4 +863,4 @@ The cache store can be customized in `config/cache.php`.
 ],
 ```
 
-By default, running `artisan cache:clear` won't clear Statamic's cache store. To do this, run `php please static:clear`.
+By default, running `php artisan cache:clear` won't clear Statamic's cache store. To do this, run `php please static:clear`.


### PR DESCRIPTION
Removed </Ifmodule> as there was no start-mention of this..
I think it would be logical to OR
 * add `<IfModule mod_rewrite.c>` to the top of the snippet
 * remove the `</IfModule>` because there was no start-IfModule

To have this </IfModule> might seem logical to most of us if you have .htaccess experience. If there was no start-tag, you will get an error on apache. Also, most hosting companies are providing Apache2 with mod-rewrite as most CMS'es required it these days.

Hope my comment makes some sense :-)
