### PR TITLE
Add details to entryBlueprintFound event

### DIFF
--- a/content/collections/extending-docs/events.md
+++ b/content/collections/extending-docs/events.md
@@ -374,6 +374,25 @@ public function handle(EntryBlueprintFound $event)
 }
 ```
 
+You can also use this to replace the whole blueprint content. 
+An example would be if you have a collection that should use a blueprint from another collection.
+
+```php
+use Statamic\Facades\Blueprint;
+
+public function handle(EntryBlueprintFound $event)
+{
+    if ($event->blueprint->fullyQualifiedHandle() === 'collections.subpages.subpage') {
+        $pageBlueprint = Blueprint::find('collections.pages.page');
+        
+        $event->blueprint->setContents($pageBlueprint->contents());
+        
+        // The entrys blueprint would be `subpage`, but the blueprint
+        // fields etc. would be the same as in `page`.
+    }
+}
+```
+
 ### EntryCreated
 `Statamic\Events\EntryCreated`
 


### PR DESCRIPTION
Adding details to the `entryBlueprintFound` event, as clarified in https://github.com/statamic/cms/issues/11916

As there are more events like this (e. g. `assetBlueprintFound` etc.) – would you like me to document the same thing there as well? Or simply add a note and an anchor link to the entry-event?