### PR TITLE
[5.x] Add a paragraph about user UUIDs in the `sessions` table.

### DIFF
--- a/content/collections/tips/storing-users-in-a-database.md
+++ b/content/collections/tips/storing-users-in-a-database.md
@@ -88,6 +88,12 @@ Statamic comes with an Eloquent driver to make the transition as seamless as pos
             $table->string('group_id');
         });
         ```
+    - If you're using the `database` session driver and using UUIDs as the primary key for users, make sure to update the `user_id` column in the `sessions` table.
+        ```php
+        Schema::table('sessions', function (Blueprint $table) {  // [tl! ++] [tl! **]
+            $table->foreignUuid('user_id')->nullable()->change();  // [tl! ++] [tl! **]
+        });  // [tl! ++] [tl! **]
+        ```
     - If you've customized your `user` blueprint, edit the migration so it includes those fields as columns. You can also create a new migration file by running `php artisan make:migration`. You'll have to manually edit the migration file to reflect your changes. Read up on [Laravel database migrations here](https://laravel.com/docs/12.x/migrations).
         ```php
         $table->string('some_field');


### PR DESCRIPTION
This PR adds a paragraph to 'Storing users in a database'. When switchting to Eloquent users and keeping UUIDs, the `user_id` column on the `sessions` table also needs to be changed. `SESSION_DRIVER=database` is the default in `laravel/laravel` now and not changing the column type leads to sessions not persisting.