### PR TITLE
Revert "Bump vite from 5.4.11 to 5.4.19"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "postcss": "^8.4.47",
                 "postcss-import": "^15.1.0",
                 "postcss-nesting": "^12.1.5",
-                "vite": "5.4.19"
+                "vite": "5.4.11"
             }
         },
         "node_modules/@algolia/autocomplete-core": {
@@ -1969,11 +1969,10 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "5.4.19",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-            "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-nesting": "^12.1.5",
-        "vite": "5.4.19"
+        "vite": "5.4.11"
     },
     "dependencies": {
         "@docsearch/js": "^3.0.0-alpha.40",


### PR DESCRIPTION
Reverts statamic/docs#1706

It looks like this update caused `npm run build` to error out on the server. Hoping that reverting fixes it 🤞