### PR TITLE
Add a tip about ensuring parent entry in tree

### DIFF
--- a/content/collections/repositories/entry-repository.md
+++ b/content/collections/repositories/entry-repository.md
@@ -242,6 +242,10 @@ $entry->afterSave(function ($entry) {
 $entry->save();
 ```
 
+:::tip
+Make sure the parent entry exists in the tree by appending it in an "afterSave" callback with `->append($entry)` just like in the example above.
+:::
+
 ### Localization
 
 #### Localizing an entry


### PR DESCRIPTION
Often, folks miss the part that parent entries need to exist in the tree before child entries can be appended to them (https://discord.com/channels/489818810157891584/1407984585110720524). It's kind of in the [docs](https://statamic.dev/repositories/entry-repository#setting-an-entrys-parent), but I think it can be improved. So, I added a hint. 

But maybe it makes sense to extend the example like this:

```php
$parent = Entry::make()
    ->collection('pages')
    ->slug('parent')
    ->data([
        // ...
    ]);

$parent->afterSave(function ($entry) {
    $entry->collection()
        ->structure()
        ->in($entry->locale())
        ->append($entry)
        ->save();
});

$parent->save();

$entry = Entry::make()
    ->collection('pages')
    ->slug('about')
    ->data([
        // ...
    ]);

$entry->afterSave(function ($entry) use ($parent) {
    $entry->collection()
        ->structure()
        ->in($entry->locale())
        ->appendTo($parent->id(), $entry->id())
        ->save();
});

$entry->save();
```

Or even add a separate example for "Adding an entry to the tree" like this:
```php
$entry = Entry::make()
    ->collection('pages')
    ->slug('about')
    ->data([
        // ...
    ]);

$entry->afterSave(function ($entry) {
    $entry->collection()
        ->structure()
        ->in($entry->locale())
        ->append($entry)
        ->save();
});

$entry->save();
```