### PR TITLE
Broaden context for "control-panel-page-expired"

### DIFF
--- a/content/collections/troubleshooting/control-panel-page-expired.md
+++ b/content/collections/troubleshooting/control-panel-page-expired.md
@@ -1,17 +1,17 @@
 ---
 id: 3faef3ae-8673-42ba-901b-a1d7eb3db4b7
 blueprint: troubleshooting
-title: '"419 Page Expired" error when logging into the Control Panel'
+title: '"419 Page Expired" error or infinite auth loop when logging into the Control Panel'
 categories:
   - troubleshooting
 template: page
 ---
-There are a few common reasons why you might encounter a "419 Page Expired" error when attempting to login to the Control Panel.
+There are a few common reasons why you might encounter a "419 Page Expired" error or an infinite authentication loop/redirect when attempting to login to the Control Panel.
 
 ## Database session driver
 The most common reason you'll see this error is if you're using the [`database` session driver](https://laravel.com/docs/session#database).
 
-The `user_id` column on the `sessions` table expects an integer value. However, because Statamic uses UUIDs for user IDs, the session row is saved incorrectly, causing the 419 error.
+The `user_id` column on the `sessions` table expects an integer value. However, because Statamic uses UUIDs for user IDs, the session row is saved incorrectly, causing either a 419 error or a continuous redirect back to the login form—even after a successful login.
 
 You can workaround this by changing the `user_id` column to a string/varchar:
 

--- a/content/collections/troubleshooting/control-panel-page-expired.md
+++ b/content/collections/troubleshooting/control-panel-page-expired.md
@@ -11,7 +11,7 @@ There are a few common reasons why you might encounter a "419 Page Expired" erro
 ## Database session driver
 The most common reason you'll see this error is if you're using the [`database` session driver](https://laravel.com/docs/session#database).
 
-The `user_id` column on the `sessions` table expects an integer value. However, because Statamic uses UUIDs for user IDs, the session row is saved incorrectly, causing either a 419 error or a continuous redirect back to the login form—even after a successful login.
+The `user_id` column on the `sessions` table expects an integer value. However, because Statamic uses UUIDs for user IDs, the session row is saved incorrectly, causing either a 419 error or a continuous redirect back to the login form—even after correct login credentials are provided.
 
 You can workaround this by changing the `user_id` column to a string/varchar:
 


### PR DESCRIPTION
Not sure if the 419 behavior still happens, but I stumbled onto something similar where you're just stuck in an infinite auth cycle—completing the form with valid credentials loops you back to the login page via a couple of 302 redirects, with no context. The solution listed on this troubleshooting page solved it, though (`user_id` must be a `varchar`) so felt like it made sense as an addition here, instead of a whole new page.