### PR TITLE
Versioning tweaks

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -9,6 +9,7 @@ return [
             'version' => '6',
             'branch' => '6.x',
             'url' => 'https://v6.statamic.dev',
+            'alpha' => true,
         ],
         [
             'version' => '5',

--- a/resources/views/partials/site_header.antlers.html
+++ b/resources/views/partials/site_header.antlers.html
@@ -71,7 +71,7 @@
             >
                 {{ config:docs:versions }}
                     <option value="{{ version }}" data-url="{{ url }}">
-                        {{ branch }}{{ if version === '6' }}-alpha{{ /if }}
+                        {{ branch }}{{ if alpha }}-alpha{{ /if }}
                     </option>
                 {{ /config:docs:versions }}
             </select>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,3 +38,5 @@ Route::get('/from/{id?}', function ($id = null) {
 
     return redirect()->to($entry->url());
 });
+
+Route::get('versions.json', fn () => config('docs.versions'));


### PR DESCRIPTION
This pull request adds an `alpha` flag to the `docs.versions` config, instead of it being hard-coded inside the version selector.

This PR also adds a `/versions.json` route, initially intended to be used by the [Raycast extension](https://www.raycast.com/andrebreia/statamic-docs), which returns an array of available versions.