### PR TITLE
Fix typo in size_kilobytes.md

### DIFF
--- a/content/collections/variables/size_kilobytes.md
+++ b/content/collections/variables/size_kilobytes.md
@@ -15,7 +15,7 @@ The file size of the asset, in kilobytes. Also available as `size_kb`.
 ```
 ::tab blade
 ```blade
-{{ $size_kiobytes }}
+{{ $size_kilobytes }}
 ```
 ::
 


### PR DESCRIPTION
The {{ $size_kiobytes }} variable has been updated to the correct spelling, {{ $size_kilobytes }}.

Changes
Fixed the typo.
Aligned the variable naming with the standards used in other files.
Tests
The file was reviewed, and no other issues were found.
The change is consistent with the existing documentation structure.