### PR TITLE
[6.x] Restore search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "livewire/livewire": "^3.6.4",
         "statamic-rad-pack/meilisearch": "dev-statamic-6",
         "statamic/cms": "^v6.0.0-alpha.9",
-        "torchlight/engine": "^0.1.0"
+        "torchlight/engine": "^0.1.0",
+        "stillat/documentation-search": "^1.3.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.16",

--- a/config/statamic/search.php
+++ b/config/statamic/search.php
@@ -27,8 +27,8 @@ return [
 
         'docs-'.config('docs.version') => [
             'driver' => env('SEARCH_DRIVER', 'meilisearch'),
-            // 'searchables' => ['docs:*'],
-            'searchables' => ['collection:*', 'taxonomy:*'],
+            'searchables' => ['docs:*'],
+            // 'searchables' => ['collection:*', 'taxonomy:*'],
             'fields' => [
                 'title',
                 'search_title',


### PR DESCRIPTION
Adds back search dependency (new version), updates configs to restore the search index behavior.

Before:

<img width="1291" height="923" alt="image" src="https://github.com/user-attachments/assets/11f6b6df-f0f4-47e6-9ff8-c019fcc7fd12" />

Side note: it makes me unreasonably happy that the first result there is a Casper reference.

After:

<img width="1248" height="925" alt="image" src="https://github.com/user-attachments/assets/349f5a17-caab-4acb-8753-04a417f5bc01" />
