### PR TITLE
[6.x] Improve search result category

### DIFF
--- a/app/Search/Listeners/SearchEntriesCreatedListener.php
+++ b/app/Search/Listeners/SearchEntriesCreatedListener.php
@@ -55,7 +55,11 @@ class SearchEntriesCreatedListener
 
         foreach ($event->sections as $section) {
             $data = $section->searchEntry->data();
-            $category = $collection.' » '.$data['origin_title'];
+
+            $category = match (true) {
+                $collection === 'Pages' => ($event->entry->parent() ? $event->entry->parent()?->title.' » ' : null).$data['origin_title'],
+                default => $collection.' » '.$data['origin_title'],
+            };
 
             $parentHeadings = null;
 


### PR DESCRIPTION
This pull request makes a small improvement to the categories of search results.

For example, if you search for "Vite Tooling" right now, the category will be `Pages » Vite Tooling`. However, this PR ensures that the parent page's title is used, so it'll become `Addons » Vite Tooling` instead.
