### PR TITLE
Add warning that caching needs to be disabled

### DIFF
--- a/content/collections/docs/graphql.md
+++ b/content/collections/docs/graphql.md
@@ -1521,6 +1521,10 @@ EntriesQuery::auth(function () {
 });
 ```
 
+:::warning
+Make sure to [disable caching](#disabling-caching) when using authorization. Otherwise the cached authorized response will be served even to unauthorized clients!
+:::
+
 ## Custom fields
 
 You can add fields to certain types by using the `addField` method on the facade.


### PR DESCRIPTION
It is important to disable caching when using the GraphQL API with authorisation. Otherwise the authorised response will be served even to unauthorised clients.

See discussion on [discord](https://discord.com/channels/489818810157891584/489818810157891586/1441339700991365172).