### PR TITLE
[6.x] Make Storybook pages searchable

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Markdown\Hint\HintExtension;
 use App\Markdown\Tabs\TabbedCodeBlockExtension;
 use App\Search\Listeners\SearchEntriesCreatedListener;
+use App\Search\Storybook\StorybookSearchProvider;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
@@ -55,5 +56,7 @@ class AppServiceProvider extends ServiceProvider
         }
 
         Event::listen(SearchEntriesCreated::class, SearchEntriesCreatedListener::class);
+
+        StorybookSearchProvider::register();
     }
 }

--- a/app/Search/Storybook/StorybookSearchProvider.php
+++ b/app/Search/Storybook/StorybookSearchProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Search\Storybook;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
+use Statamic\Search\Searchables\Provider;
+
+class StorybookSearchProvider extends Provider
+{
+    protected static $handle = 'storybook';
+
+    protected static $referencePrefix = 'storybook';
+
+    public function provide(): Collection|LazyCollection
+    {
+        return Http::get('https://ui.statamic.dev/index.json')
+            ->collect('entries')
+            ->filter(fn (array $story) => Str::endsWith($story['id'], ['--docs', '--default']))
+            ->unique('title')
+            ->map(fn (array $story) => StorybookSearchable::from($story));
+    }
+
+    public function contains($searchable): bool
+    {
+        // TODO: Implement contains() method.
+    }
+
+    public function find(array $keys): Collection
+    {
+        $stories = Http::get('https://ui.statamic.dev/index.json')->collect('entries');
+
+        return collect($keys)->map(fn (string $key) => StorybookSearchable::from($stories->get($key)));
+    }
+}

--- a/app/Search/Storybook/StorybookSearchable.php
+++ b/app/Search/Storybook/StorybookSearchable.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Search\Storybook;
+
+use Illuminate\Support\Str;
+use Statamic\Contracts\Search\Searchable as SearchableContract;
+use Statamic\Search\Searchable;
+
+class StorybookSearchable implements SearchableContract
+{
+    use Searchable;
+
+    protected string $id;
+    protected string $title;
+
+    public static function from(array $component)
+    {
+        $instance = new static();
+
+        $instance->id = $component['id'];
+        $instance->title = Str::after($component['title'], 'Components/');
+
+        return $instance;
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    public function getSearchValue(string $field)
+    {
+        if ($field === 'title' || $field === 'origin_title' || $field === 'search_title') {
+            return $this->title();
+        }
+
+        if ($field === 'hierarchy_lvl0') {
+            return "UI Components » {$this->title()}";
+        }
+
+        if ($field === 'url') {
+            return $this->url();
+        }
+
+        return null;
+    }
+
+    public function url(): string
+    {
+        return "https://ui.statamic.dev/?path=/docs/{$this->id}";
+    }
+
+    public function reference(): string
+    {
+        return "storybook::{$this->id()}";
+    }
+}

--- a/config/statamic/search.php
+++ b/config/statamic/search.php
@@ -27,8 +27,7 @@ return [
 
         'docs-'.config('docs.version') => [
             'driver' => env('SEARCH_DRIVER', 'meilisearch'),
-            'searchables' => ['docs:*'],
-            // 'searchables' => ['collection:*', 'taxonomy:*'],
+            'searchables' => ['docs:*', 'storybook:*'],
             'fields' => [
                 'title',
                 'search_title',


### PR DESCRIPTION
This pull request implements a custom searchable in order to push pages from [our Storybook docs](https://ui.statamic.dev) into the site search.

The results aren't as detailed as the others, but it's better needing to click a link on the "All UI Components" page to get where you want to go.