### PR TITLE
Fix syntax for Antlers partial inclusion in Blade templates

### DIFF
--- a/content/collections/docs/blade.md
+++ b/content/collections/docs/blade.md
@@ -181,11 +181,11 @@ We can also pass dynamic values to parameters:
 Partials also work with Antlers Blade components, and are intended to be used when you'd like to include an Antlers partial inside your Blade template:
 
 ```blade
-<s:partial/the-partial-name>
+<s:partial:the-partial-name>
   <s:slot:header>The header content.</s:slot:header>
 
   Default slot content.
-</s:partial/the-partial-name>
+</s:partial:the-partial-name>
 ```
 
 :::tip


### PR DESCRIPTION
Updated the syntax for including Antlers partials in Blade templates.