### PR TITLE
fix: hook name before-close

### DIFF
--- a/content/collections/extending-docs/hooks.md
+++ b/content/collections/extending-docs/hooks.md
@@ -85,7 +85,7 @@ Triggered immediately after the opening form tag. The payload is an array contai
 - 'html' - A string containing the rendered markup of the form so far. Modifications to this string will affect the final rendered markup.
 - 'data' - the data assembled about the form (config, blueprint, sections etc.)
 
-### Form tag: `before-open`
+### Form tag: `before-close`
 Triggered immediately before the closing form tag. The payload is an array containing two properties:
 - 'html' - A string containing the rendered markup of the form so far. Modifications to this string will affect the final rendered markup.
 - 'data' - the data assembled about the form (config, blueprint, sections etc.)


### PR DESCRIPTION
The "before-open" hook does not exist. Probably a misspell from the "after-open" hook in the paragraph before