### PR TITLE
[6.x] Add `/llms.txt` and support `.md` file extension

### DIFF
--- a/app/Http/Controllers/DocsMarkdownController.php
+++ b/app/Http/Controllers/DocsMarkdownController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Data;
+
+class DocsMarkdownController extends Controller
+{
+    public function __invoke(string $uri)
+    {
+        $entry = Data::findByUri('/'.$uri);
+
+        throw_unless($entry, new NotFoundHttpException);
+
+        $markdown = collect([
+            '# '.$entry->value('title'),
+            $entry->value('intro'),
+            $entry->value('content'),
+        ])->filter()->implode("\n\n");
+
+        return response($markdown, 200, [
+            'Content-Type' => 'text/markdown; charset=UTF-8',
+        ]);
+    }
+}

--- a/app/Http/Controllers/DocsMarkdownController.php
+++ b/app/Http/Controllers/DocsMarkdownController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Support\Facades\Cache;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Data;
 
@@ -9,15 +10,17 @@ class DocsMarkdownController extends Controller
 {
     public function __invoke(string $uri)
     {
-        $entry = Data::findByUri('/'.$uri);
+        $markdown = Cache::rememberForever("markdown.$uri", function () use ($uri) {
+            $entry = Data::findByUri('/'.$uri);
 
-        throw_unless($entry, new NotFoundHttpException);
+            throw_unless($entry, new NotFoundHttpException);
 
-        $markdown = collect([
-            '# '.$entry->value('title'),
-            $entry->value('intro'),
-            $entry->value('content'),
-        ])->filter()->implode("\n\n");
+            return collect([
+                '# '.$entry->value('title'),
+                $entry->value('intro'),
+                $entry->value('content'),
+            ])->filter()->implode("\n\n");
+        });
 
         return response($markdown, 200, [
             'Content-Type' => 'text/markdown; charset=UTF-8',

--- a/app/Http/Controllers/LlmsTxtController.php
+++ b/app/Http/Controllers/LlmsTxtController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+
+class LlmsTxtController extends Controller
+{
+    public function __invoke()
+    {
+        $tree = Collection::find('pages')->structure()->trees()->first()->tree();
+        $lines = ['# Statamic Documentation', ''];
+
+        foreach ($tree as $section) {
+            $children = $section['children'] ?? [];
+
+            if (! $children) {
+                continue;
+            }
+
+            $sectionEntry = Entry::find($section['entry']);
+            $lines[] = '## '.$sectionEntry->value('title');
+
+            $firstChild = Entry::find($children[0]['entry']);
+            if ($firstChild && str_contains($firstChild->slug(), 'overview')) {
+                if ($intro = $firstChild->value('intro')) {
+                    $lines[] = '> '.str_replace("\n", ' ', $intro);
+                }
+            }
+
+            $lines[] = '';
+
+            foreach ($children as $child) {
+                $entry = Entry::find($child['entry']);
+                if (! $entry) {
+                    continue;
+                }
+
+                $url = $entry->url();
+                if (! $url) {
+                    continue;
+                }
+
+                $title = $entry->value('title');
+                $isExternal = str_starts_with($url, 'http');
+                $href = $isExternal ? $url : url($url).'.md';
+                $line = '- ['.$title.']('.$href.')';
+
+                if ($intro = $entry->value('intro')) {
+                    $line .= ': '.str_replace("\n", ' ', $intro);
+                }
+
+                $lines[] = $line;
+            }
+
+            $lines[] = '';
+        }
+
+        return response(implode("\n", $lines), 200, [
+            'Content-Type' => 'text/plain; charset=UTF-8',
+        ]);
+    }
+}

--- a/app/Http/Controllers/LlmsTxtController.php
+++ b/app/Http/Controllers/LlmsTxtController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 
@@ -9,53 +10,57 @@ class LlmsTxtController extends Controller
 {
     public function __invoke()
     {
-        $tree = Collection::find('pages')->structure()->trees()->first()->tree();
-        $lines = ['# Statamic Documentation', ''];
+        $lines = Cache::rememberForever("llms.txt", function () {
+            $tree = Collection::find('pages')->structure()->trees()->first()->tree();
+            $lines = ['# Statamic Documentation', ''];
 
-        foreach ($tree as $section) {
-            $children = $section['children'] ?? [];
+            foreach ($tree as $section) {
+                $children = $section['children'] ?? [];
 
-            if (! $children) {
-                continue;
-            }
-
-            $sectionEntry = Entry::find($section['entry']);
-            $lines[] = '## '.$sectionEntry->value('title');
-
-            $firstChild = Entry::find($children[0]['entry']);
-            if ($firstChild && str_contains($firstChild->slug(), 'overview')) {
-                if ($intro = $firstChild->value('intro')) {
-                    $lines[] = '> '.str_replace("\n", ' ', $intro);
-                }
-            }
-
-            $lines[] = '';
-
-            foreach ($children as $child) {
-                $entry = Entry::find($child['entry']);
-                if (! $entry) {
+                if (! $children) {
                     continue;
                 }
 
-                $url = $entry->url();
-                if (! $url) {
-                    continue;
+                $sectionEntry = Entry::find($section['entry']);
+                $lines[] = '## '.$sectionEntry->value('title');
+
+                $firstChild = Entry::find($children[0]['entry']);
+                if ($firstChild && str_contains($firstChild->slug(), 'overview')) {
+                    if ($intro = $firstChild->value('intro')) {
+                        $lines[] = '> '.str_replace("\n", ' ', $intro);
+                    }
                 }
 
-                $title = $entry->value('title');
-                $isExternal = str_starts_with($url, 'http');
-                $href = $isExternal ? $url : url($url).'.md';
-                $line = '- ['.$title.']('.$href.')';
+                $lines[] = '';
 
-                if ($intro = $entry->value('intro')) {
-                    $line .= ': '.str_replace("\n", ' ', $intro);
+                foreach ($children as $child) {
+                    $entry = Entry::find($child['entry']);
+                    if (! $entry) {
+                        continue;
+                    }
+
+                    $url = $entry->url();
+                    if (! $url) {
+                        continue;
+                    }
+
+                    $title = $entry->value('title');
+                    $isExternal = str_starts_with($url, 'http');
+                    $href = $isExternal ? $url : url($url).'.md';
+                    $line = '- ['.$title.']('.$href.')';
+
+                    if ($intro = $entry->value('intro')) {
+                        $line .= ': '.str_replace("\n", ' ', $intro);
+                    }
+
+                    $lines[] = $line;
                 }
 
-                $lines[] = $line;
+                $lines[] = '';
             }
 
-            $lines[] = '';
-        }
+            return $lines;
+        });
 
         return response(implode("\n", $lines), 200, [
             'Content-Type' => 'text/plain; charset=UTF-8',

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,11 @@
 <?php
 
+use App\Http\Controllers\LlmsTxtController;
+use App\Http\Controllers\DocsMarkdownController;
 use Statamic\Facades\Entry;
+
+Route::get('llms.txt', LlmsTxtController::class);
+Route::get('{any}.md', DocsMarkdownController::class)->where('any', '.*');
 
 Route::statamic('search-results', 'search', ['hide_sidebar' => true]);
 Route::statamic('sitemap.xml', 'sitemap', ['content_type' => 'xml', 'layout' => 'sitemap']);


### PR DESCRIPTION
This pull request adds an [`/llms.txt`](https://v6.statamic.dev/llms.txt) route, and adds support for `.md` file extensions, designed to save tokens when working with an LLM.