### PR TITLE
Fix docs search box disappearing on navigation

### DIFF
--- a/resources/js/docsearch.js
+++ b/resources/js/docsearch.js
@@ -9,10 +9,18 @@ let hotKeys = [
     "/",
 ];
 
-docsearch({
-    container: "#docsearch",
-    host: "https://search.statamic.dev",
-    apiKey: "a8b8f82076221f9595dceca971be29c36cbccd772de5dbdb7f43dfac41557f95",
-    indexUid: `docs-${import.meta.env.VITE_STATAMIC_DOCS_VERSION}`,
-    hotKeys: hotKeys,
-});
+function initDocsearch() {
+    const container = document.querySelector("#docsearch");
+    if (!container || container.childElementCount > 0) return;
+
+    docsearch({
+        container: "#docsearch",
+        host: "https://search.statamic.dev",
+        apiKey: "a8b8f82076221f9595dceca971be29c36cbccd772de5dbdb7f43dfac41557f95",
+        indexUid: `docs-${import.meta.env.VITE_STATAMIC_DOCS_VERSION}`,
+        hotKeys: hotKeys,
+    });
+}
+
+initDocsearch();
+document.addEventListener("livewire:navigated", initDocsearch);


### PR DESCRIPTION
When changing pages, the docs search box disappears. The search still works if you invoke it via cmd+k.

It works fine on the v6 branch.

This PR fixes it on the v5 branch by reinitializing on livewire navigation.
