### PR TITLE
Update link in vue-2-to-3.md for Publish component

### DIFF
--- a/content/collections/pages/vue-2-to-3.md
+++ b/content/collections/pages/vue-2-to-3.md
@@ -448,7 +448,7 @@ import { PublishContainer } from '@statamic/cms/ui';
 </template>
 ```
 
-View the [Publish component docs page](/ui-components/publish) for more details.
+View the [Publish component docs page](https://ui.statamic.dev/?path=/docs/components-publishcontainer--docs) for more details.
 
 
 ### Listing


### PR DESCRIPTION
Fixed incorrect link in https://statamic.dev/getting-started/upgrade-guide/vue-2-to-3#publish

 - Currently: https://ui.statamic.dev/?path=/docs/components-publish
 - Changed to: https://ui.statamic.dev/?path=/docs/components-publishcontainer--docs<br/>_Similar to link in https://statamic.dev/getting-started/upgrade-guide/vue-2-to-3#listing_