### PR TITLE
Fix typo in email-not-sending.md

### DIFF
--- a/content/collections/troubleshooting/email-not-sending.md
+++ b/content/collections/troubleshooting/email-not-sending.md
@@ -27,7 +27,7 @@ Locally, run the queue worker:
 php artisan queue:listen
 ```
 
-Or on production, make sure you a worker configured to run the `queue:work` command.
+Or on production, make sure you have a worker configured to run the `queue:work` command.
 
 ## Horizon
 


### PR DESCRIPTION
I noticed the verb "have" is missing in the Queue section of the email-not-sending.md page