### PR TITLE
Document rate limiting for auth, passkeys, and form submissions

### DIFF
--- a/content/collections/pages/forms.md
+++ b/content/collections/pages/forms.md
@@ -585,6 +585,27 @@ You'll also need to set your ajax library's `X-Requested-With` header to `XMLHtt
 
 The URL endpoint to send the request to is `/!/forms/{form-handle}`. You can configure the action route prefix which defaults to `!` in `config/statamic/routes.php`.
 
+## Rate limiting
+
+Form submissions are rate limited by IP address to help protect against abuse. By default, the `statamic.forms` limiter allows 10 submissions per minute across all forms.
+
+You can customize the limit by redefining the named rate limiter in your `AppServiceProvider`'s `boot` method:
+
+```php
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+
+public function boot()
+{
+    RateLimiter::for('statamic.forms', function (Request $request) {
+        return Limit::perMinute(20)->by($request->ip());
+    });
+}
+```
+
+Consult the [Laravel documentation](https://laravel.com/docs/13.x/routing#rate-limiting) to learn more about defining rate limiters.
+
 ## Caching
 
 If you are static caching the URL containing a form, return responses like 'success' and 'errors' will not be available after submitting unless you [exclude this page from caching](/static-caching#excluding-pages) or wrap the form in {{ nocache }} tags.

--- a/content/collections/pages/users.md
+++ b/content/collections/pages/users.md
@@ -303,3 +303,33 @@ Click **Create Passkey** and follow the prompts to complete setup. Once a passke
 </figure>
 
 Passkey behaviour, including whether password logins are still allowed for users with passkeys and whether “remember me” applies when logging in with a passkey, can be configured in `config/statamic/webauthn.php`.
+
+## Rate limiting
+
+Statamic's authentication and passkey endpoints are rate limited by IP address to help protect against brute force attacks. The defaults apply to both the front-end and Control Panel:
+
+| Limiter | Default | Routes |
+| --- | --- | --- |
+| `statamic.auth` | 4 per minute | Front-end login, register, password email, password reset |
+| `statamic.cp.auth` | Inherits `statamic.auth` | Control Panel login, password email, password reset |
+| `statamic.passkeys` | 30 per minute | Front-end passkey authentication |
+| `statamic.cp.passkeys` | Inherits `statamic.passkeys` | Control Panel passkey authentication |
+
+You can customize any of these limits by redefining the named rate limiter in your `AppServiceProvider`'s `boot` method:
+
+```php
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+
+public function boot()
+{
+    RateLimiter::for('statamic.auth', function (Request $request) {
+        return Limit::perMinute(10)->by($request->ip());
+    });
+}
+```
+
+Overriding `statamic.auth` will affect both the front-end and Control Panel buckets unless you also define a separate `statamic.cp.auth` limiter. The same inheritance applies to `statamic.passkeys` and `statamic.cp.passkeys`.
+
+Consult the [Laravel documentation](https://laravel.com/docs/13.x/routing#rate-limiting) to learn more about defining rate limiters.


### PR DESCRIPTION
## Summary

Documents the named rate limiters added to Statamic 6.x in [statamic/cms#14475](https://github.com/statamic/cms/pull/14475).

- Adds a "Rate limiting" section to `users.md` covering the `statamic.auth`, `statamic.cp.auth`, `statamic.passkeys`, and `statamic.cp.passkeys` limiters, with defaults, route coverage, and an override example via `RateLimiter::for()` in `AppServiceProvider`. Explains that the CP limiters inherit from the front-end ones unless separately defined.
- Adds a "Rate limiting" section to `forms.md` covering the `statamic.forms` limiter (10/min default) and how to override it.

## Notes

- statamic/cms#14475 is still open as of writing — the limiter names and defaults may change before it's merged, so these docs may need a follow-up pass before publishing.
- The CMS PR's description mentions `auth_middleware` / `forms_middleware` config keys, but the actual implementation uses named Laravel rate limiters. This PR documents what the code actually does.

## Test plan

- [ ] Confirm limiter names and defaults match what ships in 6.x once statamic/cms#14475 is merged
- [ ] Render both pages locally and verify the new sections appear where expected