### PR TITLE
Update install instructions for Ubuntu 24.04

### DIFF
--- a/content/collections/pages/digital-ocean.md
+++ b/content/collections/pages/digital-ocean.md
@@ -4,19 +4,19 @@ blueprint: page
 title: 'How to Install Statamic on Digital Ocean'
 breadcrumb_title: 'Digital Ocean'
 parent: ab08f409-8bbe-4ede-b421-d05777d292f7
-intro: A full walk-through for installing, configuring, and running Statamic on a Digital Ocean Ubuntu virtual private server.
+intro: 'A full walk-through for installing, configuring, and running Statamic on a Digital Ocean Ubuntu virtual private server.'
 ---
 ## Prerequisites
 
 There is only one prerequisite for this guide. You must have:
 
-- A Digital Ocean account ([this signup link](https://m.do.co/c/6469827e2269)  will give you $100 in free credit)
+- A Digital Ocean account ([this signup link](https://m.do.co/c/6469827e2269) will give you $100 in free credit)
 
 ## Server Setup
 
-Follow the official [How to Set Up an Ubuntu 20.04 Server on a DigitalOcean Droplet](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-ubuntu-20-04-server-on-a-digitalocean-droplet) guide to setup your server.
+Follow the official [How To Set Up an Ubuntu Server on a DigitalOcean Droplet](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-ubuntu-server-on-a-digitalocean-droplet) guide to setup your server.
 
-<a href="(https://m.do.co/c/6469827e2269"><img src="https://images.prismic.io/digitalocean/0b619d51-a723-4748-997f-39ed5697a540_intro-to-cloud.jpg?auto=compress,format" class="rounded-lg"></a>
+<a href="https://m.do.co/c/6469827e2269"><img src="https://images.prismic.io/digitalocean/0b619d51-a723-4748-997f-39ed5697a540_intro-to-cloud.jpg?auto=compress,format" class="rounded-lg"></a>
 
 ## Secure Your Server
 

--- a/content/collections/pages/ubuntu.md
+++ b/content/collections/pages/ubuntu.md
@@ -3,18 +3,17 @@ id: c0009fa6-0f8f-4b45-8d65-0cb784d07031
 blueprint: page
 title: 'How to Install Statamic on Ubuntu'
 breadcrumb_title: Ubuntu
-intro: A full walk-through for installing, configuring and running Statamic on an Ubuntu server, perfect for production use.
+intro: 'A full walk-through for installing, configuring and running Statamic on an Ubuntu server, perfect for production use.'
 parent: ab08f409-8bbe-4ede-b421-d05777d292f7
 ---
 ## Prerequisites
 
 To install Statamic on an Ubuntu instance you will need the following:
 
-- An Ubuntu 22.04 or 20.04 VPS with root access enabled or a user with Sudo privileges (you can follow our [Digital Ocean](/installing/digital-ocean) or [Linode](/installing/linode) guides to get yours set up)
+- An Ubuntu 24.04 VPS with root access enabled or a user with sudo privileges (you can follow our [Digital Ocean](/installing/digital-ocean) or [Linode](/installing/linode) guides to get yours set up)
 - A server with at least 1GB memory
 - A valid domain name pointed to your server and SSL certificate in place
-- PHP 8.2+
-
+- PHP 8.3+
 
 ## Update Packages
 
@@ -28,7 +27,7 @@ sudo apt-get upgrade
 ## Install PHP & Required Modules
 
 ``` shell
-sudo apt install php-common php-fpm php-json php-mbstring zip unzip php-zip php-cli php-xml php-tokenizer php-curl -y
+sudo apt install php-common php-fpm php-json php-mbstring zip unzip php-zip php-cli php-xml php-tokenizer php-curl php-gd -y
 ```
 
 ## Install Composer
@@ -45,6 +44,10 @@ Next, you need to move the `composer.phar` file to a globally accessible directo
 sudo mv composer.phar /usr/local/bin/composer
 sudo chmod +x /usr/local/bin/composer
 ```
+
+:::tip
+Do not run `composer` as root. If you followed the steps for creating a Digital Ocean droplet, you will need to create a new user to run `composer` as.
+:::
 
 Now you can check to make sure Composer is installed and configured correctly by running this command:
 
@@ -64,18 +67,31 @@ Upon installation, you can now use the `statamic new` command to spin up fresh S
 
 Our CLI is essentially a super fancy wrapper around the `composer create-project` command. You can choose to not install it, but only at your own annoyance.
 
+## Install & Configure Nginx
+
+Next, install [Nginx](https://nginx.com) with the following command:
+
+``` shell
+sudo apt install nginx -y
+```
+
+After the install completes, Nginx will start automatically. You can verify the service by running the following the command:
+
+``` shell
+sudo systemctl status nginx
+```
 
 ## Create a new Statamic Application
 
 Now we'll create a new Statamic application using the `statamic new` command.
 
-First, navigate to the `/var/www` directory:
+First, navigate to the default Nginx root directory:
 
 ``` shell
-cd /var/www
+cd /var/www/html
 ```
 
-Next, run the following install command:
+Next, run the following install command (you may need to update your [$PATH](/knowledge-base/troubleshooting/command-not-found-statamic)):
 
 ``` shell
 statamic new example.com
@@ -95,35 +111,16 @@ Once Statamic is installed, you'll need to grant appropriate permissions to the 
 
 ``` shell
 sudo chmod -R 755 /var/www/example.com
-sudo chown -R www-data:www-data /var/www/example.com
-sudo chown -R www-data:www-data /var/www/example.com/storage
-sudo chown -R www-data:www-data /var/www/example.com/content
-sudo chown -R www-data:www-data /var/www/example.com/bootstrap/cache
+sudo chown -R www-data:www-data /var/www/html/example.com
 ```
 
-
-## Install & Configure Nginx
-
-Next, install [Nginx](https://nginx.com) with the following command:
-
-``` shell
-sudo apt install nginx -y
-```
-
-After the install completes, Nginx will start automatically. You can verify the service by running the following the command:
-
-``` shell
-sudo systemctl status nginx
-```
-
-Next, let's set up the minimum recommended config file to serve your site. Create a new file with `vim` (or your command line editor of choice) at `/etc/nginx/sites-available/example.com`, making sure to replace `example.com` everywhere with your desired domain.
-
+Next, let's set up the minimum recommended config file to serve your site. Create a new file with `sudo vim` (or your command line editor of choice) at `/etc/nginx/sites-available/example.com`, making sure to replace `example.com` everywhere with your desired domain.
 
 ```php
 server {
     listen 80;
     server_name example.com; // [tl! highlight:1]
-    root /var/www/example.com/public;
+    root /var/www/html/example.com/public;
 
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
@@ -161,7 +158,7 @@ server {
     error_page 404 /index.php;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/var/run/php/php8.1-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
@@ -176,7 +173,7 @@ server {
 :::tip
 You should ensure that the PHP path matches the version of PHP-FPM you have installed. 
 
-For example: the example config above specifies `fastcgi_pass unix:/var/run/php/php8.1-fpm.sock;`, but if you update all packages, you may end up with a later version.
+For example: the example config above specifies `fastcgi_pass unix:/var/run/php/php8.3-fpm.sock;`, but if you update all packages, you may end up with a later version.
 :::
 
 You can confirm that the configuration doesn’t contain any syntax errors with the following command:
@@ -193,9 +190,10 @@ nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
 nginx: configuration file /etc/nginx/nginx.conf test is successful
 ```
 
-Time to reload Nginx and apply these changes:
+Symlink the newly created config file and reload Nginx to apply these changes:
 
 ``` shell
+sudo ln -s /etc/nginx/sites-available/example.com /etc/nginx/sites-enabled/
 sudo systemctl reload nginx
 ```
 

--- a/content/collections/troubleshooting/command-not-found-statamic.md
+++ b/content/collections/troubleshooting/command-not-found-statamic.md
@@ -42,7 +42,9 @@ You can solve this by adding Composer's `bin` directory to your `PATH` (sometime
 
     ``` shell
     # Replace the path below with the path identified in step 1
-    export PATH="/Users/me/.composer/vendor/bin/":$PATH
+    export PATH="/Users/me/.composer/vendor/bin/":$PATH # MacOS
+
+    export PATH="$HOME/.config/composer/vendor/bin/":$PATH # Linux
     ```
 
 To test it, open a _new_ terminal window and run `echo $PATH`. You should see the composer directory at the end.

--- a/resources/views/installing.antlers.html
+++ b/resources/views/installing.antlers.html
@@ -47,7 +47,7 @@
             </div>
         </a>
         <h2>Ubuntu</h2>
-        <p>18.04, 20.04 LTS</p>
+        <p>24.04 LTS</p>
     </div>
 </div>
 


### PR DESCRIPTION
Closes #1316

- Fixed some typos on the related DigitalOcean page
- Re-ordered the install steps as some folders don't exist until after nginx is installed
- Added instructions for $PATH variable on Linux (vs MacOS)

I'm sure this would also work in the [5.x] docs, but I don't know how to PR against two branches at once (if that's even possible).