### PR TITLE
Document cache exclusion for GraphQL responses

### DIFF
--- a/content/collections/pages/graphql.md
+++ b/content/collections/pages/graphql.md
@@ -1654,6 +1654,20 @@ Cached responses are automatically invalidated when content is changed. Dependin
 ],
 ```
 
+### Cache exclusion
+
+Responses can be excluded from the whole-response cache by adding their query names to the `exclude` array in `config/statamic/graphql.php`.
+
+```php
+'cache' => [
+    'expiry' => 60,
+    'exclude' => [
+        'ping',
+        'user',
+    ],
+],
+```
+
 ### Disabling caching
 
 If you wish to disable caching altogether, set `cache` to `false`.


### PR DESCRIPTION
Added section on cache exclusion for GraphQL responses.

Related CMS PR: https://github.com/statamic/cms/pull/14624