### PR TITLE
Document overriding date format preset options

### DIFF
--- a/content/collections/pages/formatters.md
+++ b/content/collections/pages/formatters.md
@@ -53,6 +53,22 @@ dateFormatter.format('2026-03-26', {
 // March 26, 2026
 ```
 
+### Overriding preset options
+
+To start from a preset and tweak only a few fields, pass an options object with a `preset` key alongside any other `Intl.DateTimeFormat` options. The overrides are merged on top of the preset.
+
+```js
+dateFormatter.format('2026-03-26T20:24:21', {
+    preset: 'datetime',
+    timeZone: 'Australia/Sydney',
+});
+
+dateFormatter.format('2026-03-26T20:24:21', {
+    preset: 'datetime',
+    month: 'short',
+});
+```
+
 ### Relative dates
 
 Pass `relative: true` (or a specificity) to output a humanized relative string powered by `Intl.RelativeTimeFormat`.


### PR DESCRIPTION
Documents the ability to override date format preset options on `DateFormatter`, introduced in [statamic/cms#14600](https://github.com/statamic/cms/pull/14600).

You can now pass an options object with a `preset` key alongside any other `Intl.DateTimeFormat` options, which get merged on top of the preset.

```js
dateFormatter.format('2026-03-26T20:24:21', {
    preset: 'datetime',
    timeZone: 'Australia/Sydney',
});
```

Closes #1905