### PR TITLE
Document configurable crop aspect ratios

### DIFF
--- a/content/collections/pages/assets.md
+++ b/content/collections/pages/assets.md
@@ -60,7 +60,7 @@ Most of the asset actions are also available inside the editor, along with the a
 ### Crop
 The crop action lets you visually crop an image directly in the Control Panel. It's available from the toolbar inside the [Asset Editor](#edit) for any image asset (except GIFs) when the current user has permission to upload to the container.
 
-You can drag to define a custom crop area, or pick one of the built-in aspect ratio presets: `16:9`, `4:3`, `3:2`, `2:1`, and `1:1`. A flip button rotates the ratio between landscape and portrait orientation. Hold the <kbd>Option</kbd> / <kbd>Alt</kbd> key while resizing to resize from the center, and press <kbd>Enter</kbd> to apply the crop.
+You can drag to define a custom crop area, or pick from a [predefined ratio](#customizing-aspect-ratio-presets). A flip button rotates the ratio between landscape and portrait orientation. Hold the <kbd>Option</kbd> / <kbd>Alt</kbd> key while resizing to resize from the center, and press <kbd>Enter</kbd> to apply the crop.
 
 After cropping, you'll be asked whether you want to save the crop as a **new copy** (uploaded to the same folder with a timestamped filename) or **replace the original** image. Replacing requires the user to also have the `reupload` permission on the asset.
 
@@ -68,8 +68,36 @@ After cropping, you'll be asked whether you want to save the crop as a **new cop
 Cropping external images (for example, from an S3 container on a different domain) requires that the source be served with proper CORS headers. If the image can't be loaded cross-origin, the crop editor will warn you and close.
 :::
 
-Bulk
-: No
+#### Customizing aspect ratio presets
+
+You can customize the aspect ratio presets shown in the crop editor by editing the `crop_aspect_ratios` array in `config/statamic/assets.php`.
+
+The simplest form is a list of `W:H` strings. The label shown in the dropdown will be the ratio itself.
+
+```php
+// config/statamic/assets.php
+
+'crop_aspect_ratios' => [
+    '16:9', '4:3', '3:2', '2:1', '1:1',
+],
+```
+
+If you want to give a preset a custom label, use an array with `label` and `ratio` keys. The ratio can be a `W:H` string or a number.
+
+```php
+// config/statamic/assets.php
+
+'crop_aspect_ratios' => [
+    ['label' => 'Widescreen', 'ratio' => '16:9'],
+    ['label' => 'Portrait', 'ratio' => '9:16'],
+    ['label' => 'US Letter', 'ratio' => '8.5:11'],
+    ['label' => 'Golden', 'ratio' => 1.618],
+],
+```
+
+Labels are passed through translation helpers, so you can use translation keys to localize them.
+
+Set this to an empty array to hide the aspect ratio dropdown entirely and only allow free-form crops.
 
 ### Copy URL
 Running this action allows you to copy the URL of an asset. You can use the copied URL to share or reference the asset in other places, such as in emails, documents, or on other websites.


### PR DESCRIPTION
Documents the new `crop_aspect_ratios` config option added in [statamic/cms#14630](https://github.com/statamic/cms/pull/14630) and refined in [statamic/cms#14633](https://github.com/statamic/cms/pull/14633).

Adds a "Customizing aspect ratio presets" subsection under the existing **Crop** asset action that shows the two supported entry formats — plain `W:H` strings and `['label' => ..., 'ratio' => ...]` arrays — in separate code blocks, and notes that labels are run through `__()` so they can be translation keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)