### PR TITLE
Correct is_after and is_before examples

### DIFF
--- a/content/collections/modifiers/is_after.md
+++ b/content/collections/modifiers/is_after.md
@@ -6,7 +6,7 @@ modifier_types:
   - conditions
 title: 'Is After'
 ---
-Returns `true` if a date variable is after another date. That second date can be the name of another variable or a literal date string.
+Returns `true` if a date variable is after another date. That second date can be the name of another variable, a literal date string, or any relative date format (see [PHP DateTime](https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative) for more details).
 
 ```yaml
 start_date: January 17 2015
@@ -18,13 +18,15 @@ end_date: December 1 2015
 ::tab antlers
 ```antlers
 {{ if end_date | is_after($start_date) }}
-{{ if start_date | is_after(2014) }}
+{{ if start_date | is_after("2014-01-01") }}
+{{ if start_date | is_after("-1 day") }}
 {{ if start_date | is_after($end_date) }}
 ```
 ::tab blade
 ```blade
 @if (Statamic::modify($end_date)->isAfter($start_date)->fetch()) @endif
-@if (Statamic::modify($start_date)->isAfter(2014)->fetch()) @endif
+@if (Statamic::modify($start_date)->isAfter("2014-01-01")->fetch()) @endif
+@if (Statamic::modify($start_date)->isAfter("-1 day")->fetch()) @endif
 @if (Statamic::modify($start_date)->isAfter($end_date)->fetch()) @endif
 ```
 ::
@@ -32,6 +34,7 @@ end_date: December 1 2015
 ```html
 true
 true
+false
 false
 ```
 

--- a/content/collections/modifiers/is_before.md
+++ b/content/collections/modifiers/is_before.md
@@ -6,7 +6,7 @@ modifier_types:
   - conditions
 title: 'Is Before'
 ---
-Returns `true` if a date variable is before another date. That second date can be the name of another variable or a literal date string.
+Returns `true` if a date variable is before another date. That second date can be the name of another variable, a literal date string, or any relative date format (see [PHP DateTime](https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative) for more details).
 
 ```yaml
 start_date: January 17 2015
@@ -18,18 +18,21 @@ end_date: December 1 2015
 ::tab antlers
 ```antlers
 {{ if end_date | is_before($start_date) }}
-{{ if start_date | is_before(2014) }}
+{{ if start_date | is_before("2014-01-01") }}
+{{ if start_date | is_before("-1 day") }}
 {{ if start_date | is_before($end_date) }}
 ```
 ::tab blade
 ```blade
 @if (Statamic::modify($end_date)->isBefore($start_date)->fetch()) @endif
-@if (Statamic::modify($start_date)->isBefore(2014)->fetch()) @endif
+@if (Statamic::modify($start_date)->isBefore("2014-01-01")->fetch()) @endif
+@if (Statamic::modify($start_date)->isBefore("-1 day")->fetch()) @endif
 @if (Statamic::modify($start_date)->isBefore($end_date)->fetch()) @endif
 ```
 ::
 
 ```html
+false
 false
 false
 true


### PR DESCRIPTION
OK, I went spelunking into the `isAfter` modifier code and discovered that the documentation is wrong. I think this is probably due to the adoption of Carbon dates (was Carbon adopted in v6?). The docs show `{{ if start_date | is_after(2014) }}`, which most readers would see as the year "2014", but the code treats this as "2014 seconds after the Unix epoch", which is quite different. In fact the code does this for any numeric value, whether provided as a number or a string. To get the expected result you would have to provide `is_after("2014-01-01")` or something of that sort. It turns out that `is_after("today")` does work, as does any valid Carbon relative date string, such as `-1 day` or `+2 months`.

This pull request aligns the docs with actual behavior. It does nothing to fix the behavior of numeric values, which someone might want to do in order to be backward compatible if v5 behaved as advertised.