### PR TITLE
Vite tooling hint for addons

### DIFF
--- a/content/collections/pages/building-an-addon.md
+++ b/content/collections/pages/building-an-addon.md
@@ -203,6 +203,19 @@ public function bootAddon()
 }
 ```
 
+## Including Fieldtypes with your Addon
+
+If you plan to build a [fieldtype](/fieldtypes/build-a-fieldtype) into your addon, you can do so by including your addon when you generate the fieldtype:
+
+```shell
+php please make:fieldtype Uppercase example/my-addon
+```
+
+In this case, please also pay special attention to the [Vite tooling development](/addons/vite-tooling#development) requirements. In particular, you will probably want to publish a special "dev build" so that the manifest for the fieldtype can be found within the addon:
+
+```shell
+php artisan vendor:publish --tag=my-addon
+```
 
 ## Registering Components
 


### PR DESCRIPTION
I have twice missed the very valuable information in the _Vite Tooling_ documentation because I was so focused on the _Building an Addon_ document. This pull request provides a bridge that might help future me (and others like me) who are so overwhelmed with the task of building an addon with a fieldtype that they miss important information in _Vite Tooling_.

This also provides the syntax for building fieldtypes into addons, which does not seem to be present in the docs otherwise.