### PR TITLE
Document how to just add a nav item to the CP

### DIFF
--- a/content/collections/pages/cp-navigation.md
+++ b/content/collections/pages/cp-navigation.md
@@ -38,6 +38,10 @@ public function bootAddon()
 }
 ```
 
+:::hint
+If you want nothing more than adding an item to your nav, you don't need to create a full-blown addon. Just `Nav::extend` from the `boot` method of your `AppServiceProvider`.
+:::
+
 The `content()` method there is a [magic method](http://php.net/manual/en/language.oop5.magic.php), and the name of method defines the section name that will be used.  If we need to display special characters in our section name, we can `create()` the nav item and explicitly define the section name:
 
 ```php


### PR DESCRIPTION
Came up in support so making it more clear how to easily add a nav item to the CP's sidebar. There's no need to create an addon/package. Just add the items you want to add to your existing `AppServiceProvider`. Neat if you want to link to another part of your app (outside of Statamic) or even another site (e.g. your help desk software).