### PR TITLE
The recent-updates page was missing from v6 docs

### DIFF
--- a/content/collections/pages/home.md
+++ b/content/collections/pages/home.md
@@ -67,6 +67,6 @@ tiles:
     enabled: true
     flush_image: false
     hue_rotate: false
-    tile_link: 'entry::a77eb282-e050-4288-b83d-789840e245fd'
+    tile_link: 'entry::f269a0d2-061d-4cc9-a24d-3ea82ea9558f'
 advert_override: 972d7159-e76a-4817-a441-65d965d8c794
 ---

--- a/content/collections/pages/recent-updates.md
+++ b/content/collections/pages/recent-updates.md
@@ -1,0 +1,7 @@
+---
+id: f269a0d2-061d-4cc9-a24d-3ea82ea9558f
+blueprint: page
+title: 'Recent Updates'
+intro: 'Keep your Statamic superpowers up-to-date with the latest updates to the docs.'
+template: updates
+---

--- a/content/trees/collections/pages.yaml
+++ b/content/trees/collections/pages.yaml
@@ -348,4 +348,6 @@ tree:
       -
         entry: c9ee871c-002b-48d7-b845-1abac58de337
       -
+        entry: f269a0d2-061d-4cc9-a24d-3ea82ea9558f
+      -
         entry: 550e7bf1-de6e-40ba-9b06-b32d9119e436

--- a/resources/views/home.antlers.html
+++ b/resources/views/home.antlers.html
@@ -56,30 +56,3 @@
 </div>
 
 {{ $article_footer = 'no' }}
-
-{{# =JFG. Keeping this here for now because it could be useful at some point #}}
-{{# <section class="markdown mt-6 md:mt-20">
-    <h2>Recent Updates</h2>
-    <p>Keep your Statamic superpowers up-to-date with the latest updates to the docs.</p>
-    <table>
-        <thead>
-            <tr>
-                <th>Page</th>
-                <th>The Change</th>
-                <th>Section</th>
-                <th>Last Updated</th>
-            </tr>
-        </thead>
-        <tbody>
-            {{ collection from="docs|tags|modifiers|variables|fieldtypes|screencasts" sort="last_modified:desc" limit="5" title:not="Documentation" scope="entry" }}
-                <tr>
-                    <td class="w-1/2"><a href="{{ url }}">{{ entry:title ?? entry:slug|title }}</a></td>
-                    <td><a href="{{ github_commits_url }}" target="_blank">View</a></td>
-                    <td>{{ entry:collection | deslugify | title }}</td>
-                    <td x-text="dayjs('{{ entry:last_modified format="Y-m-d H:i:s" }}').fromNow(true) + ' ago'"></td>
-                </tr>
-            {{ /collection }}
-        </tbody>
-    </table>
-    <a href="/recent-updates" class="button float-right mt-4">View all recent updates</a>
-</section> #}}

--- a/resources/views/updates.antlers.html
+++ b/resources/views/updates.antlers.html
@@ -13,7 +13,7 @@
             </tr>
         </thead>
         <tbody>
-            {{ collection from="docs|tags|modifiers|variables|fieldtypes|screencasts" sort="last_modified:desc" limit="100" title:not="Documentation" scope="entry" }}
+            {{ collection from="pages|tags|modifiers|variables|fieldtypes|tips|resource_apis" sort="last_modified:desc" limit="100" title:not="Home" scope="entry" }}
                 <tr>
                     <td class="w-1/2"><a href="{{ github_commits_url }}" target="_blank">{{ entry:title ?? entry:slug|title }}</a></td>
                     <td>{{ entry:collection | deslugify | title }}</td>

--- a/routes/redirects.php
+++ b/routes/redirects.php
@@ -149,7 +149,7 @@ Route::permanentRedirect('deploying/ploi', '/getting-started/deploying/ploi');
 Route::permanentRedirect('preferences', '/control-panel/preferences');
 Route::permanentRedirect('protecting-content', '/frontend/protecting-content');
 Route::permanentRedirect('quick-start-guide', '/getting-started/quick-start-guide');
-Route::permanentRedirect('recent-updates', '/');
+Route::permanentRedirect('recent-updates', '/knowledge-base/recent-updates');
 Route::permanentRedirect('relationships', '/content-modeling/relationships');
 Route::permanentRedirect('release-schedule-support-policy', '/knowledge-base/release-schedule-support-policy');
 Route::permanentRedirect('requirements', '/getting-started/requirements');


### PR DESCRIPTION
Also removed duplicated template code as it seems like that has no plans to be re-added to the homepage.