### PR TITLE
Update Sites API docs

### DIFF
--- a/content/collections/pages/forms.md
+++ b/content/collections/pages/forms.md
@@ -542,6 +542,30 @@ fields:
       container: main
 ```
 
+### Configuring temporary file storage
+
+When using the `files` fieldtype, uploads are temporarily stored on your server before being attached to emails and then deleted. By default, these files are stored on the `local` disk at `storage/app/private/statamic/file-uploads`.
+
+In multi-server environments where a file might be uploaded on one server but processed (eg. queued form emails) on another, you can configure the storage location to use a shared filesystem like S3:
+
+```env
+STATAMIC_FILE_UPLOADS_DISK=s3
+STATAMIC_FILE_UPLOADS_PATH=statamic/file-uploads
+```
+
+Or in your `config/statamic/system.php` file:
+
+```php
+'file_uploads' => [
+    'disk' => env('STATAMIC_FILE_UPLOADS_DISK', 'local'),
+    'path' => env('STATAMIC_FILE_UPLOADS_PATH', 'statamic/file-uploads'),
+],
+```
+
+:::tip
+Since these are temporary files containing user uploads, you should use a private filesystem to prevent unauthorized access.
+:::
+
 ## Honeypot
 
 Simple and effective spam prevention.

--- a/content/collections/pages/forms.md
+++ b/content/collections/pages/forms.md
@@ -542,30 +542,6 @@ fields:
       container: main
 ```
 
-### Configuring temporary file storage
-
-When using the `files` fieldtype, uploads are temporarily stored on your server before being attached to emails and then deleted. By default, these files are stored on the `local` disk at `storage/app/private/statamic/file-uploads`.
-
-In multi-server environments where a file might be uploaded on one server but processed (eg. queued form emails) on another, you can configure the storage location to use a shared filesystem like S3:
-
-```env
-STATAMIC_FILE_UPLOADS_DISK=s3
-STATAMIC_FILE_UPLOADS_PATH=statamic/file-uploads
-```
-
-Or in your `config/statamic/system.php` file:
-
-```php
-'file_uploads' => [
-    'disk' => env('STATAMIC_FILE_UPLOADS_DISK', 'local'),
-    'path' => env('STATAMIC_FILE_UPLOADS_PATH', 'statamic/file-uploads'),
-],
-```
-
-:::tip
-Since these are temporary files containing user uploads, you should use a private filesystem to prevent unauthorized access.
-:::
-
 ## Honeypot
 
 Simple and effective spam prevention.

--- a/content/collections/pages/sites-api.md
+++ b/content/collections/pages/sites-api.md
@@ -32,6 +32,7 @@ _*For more info, read more about [headers](https://laravel.com/docs/13.x/http-cl
 
 - [Sites Index](#sites-index)
 - [Create Site](#create-site)
+- [Update Site](#update-site)
 - [Delete Site](#delete-site)
 
 ### Sites Index
@@ -73,6 +74,9 @@ _*For more info, read more about [headers](https://laravel.com/docs/13.x/http-cl
 | --- | --- | --- |
 | `name` | yes | `Jurassic World` |
 | `domain` | no | `jurassicworld.ca` |
+| `domains` | no | `["jurassicworld.ca", "staging.jurassicworld.ca"]` |
+
+To license more than one domain (for example, a production domain and a staging domain) provide a `domains` array instead of a single `domain`. The first domain in the array is treated as the production domain and the rest as testing domains. You may provide `domain` or `domains`, but not both.
 
 #### Example Output
 
@@ -82,7 +86,38 @@ _*For more info, read more about [headers](https://laravel.com/docs/13.x/http-cl
     "name": "Jurassic World",
     "key": "pwkknrxl6y7z1n9v",
     "domains": [
-      "jurassicworld.ca"
+      "jurassicworld.ca",
+      "staging.jurassicworld.ca"
+    ],
+    "created_at": "2021-11-18 19:45:41"
+  }
+}
+```
+
+### Update Site
+
+#### `PATCH https://statamic.com/api/v1/sites/[your-site-key-here]`
+
+Any param you provide will override the site's current value. Params you leave out are left untouched. Providing `domain` or `domains` replaces _all_ of the site's existing domains.
+
+#### Params
+
+| Param | Required | Example |
+| --- | --- | --- |
+| `name` | no | `Jurassic World` |
+| `domain` | no | `jurassicworld.ca` |
+| `domains` | no | `["jurassicworld.ca", "staging.jurassicworld.ca"]` |
+
+#### Example Output
+
+```json
+{
+  "data": {
+    "name": "Jurassic World",
+    "key": "pwkknrxl6y7z1n9v",
+    "domains": [
+      "jurassicworld.ca",
+      "staging.jurassicworld.ca"
     ],
     "created_at": "2021-11-18 19:45:41"
   }


### PR DESCRIPTION
This pull request documents the new ability to manage multiple domains per site through the Sites API.

It adds a `domains` array param to the Create Site endpoint (noting the first domain is treated as production and the rest as testing), and documents the new Update Site (`PUT`/`PATCH`) endpoint.