### PR TITLE
Add recommended hosts knowledge base page

### DIFF
--- a/content/collections/pages/deploying.md
+++ b/content/collections/pages/deploying.md
@@ -6,11 +6,5 @@ blueprint: page
 content_width: max-w-4xl
 id: c4f17d05-78bd-41bf-8e06-8dd52f6ec154
 ---
-## Overview
-
-Deployments are the process of moving the Statamic site you've built — whether on your local computer or distributed across a team — to the production (aka "live") server for the whole world (wide web) to see.
-
-At its most simple level, it's just the act of moving files from your computer to another computer — the web server. There are many ways to do it, from a slow and painfully manual FTP upload (please don't), to a lightning quick git push with auto-deployment.
-
-The deployment options available to you will depend on the type of hosting scenario you're using.
+If you're still choosing where to host, take a look at our [recommended hosts](/knowledge-base/recommended-hosts).
 

--- a/content/collections/pages/recommended-hosts.md
+++ b/content/collections/pages/recommended-hosts.md
@@ -1,0 +1,53 @@
+---
+id: 774b3b8f-a328-469f-ab87-04a41e290ddd
+blueprint: page
+title: 'Recommended Hosts'
+intro: 'A user-curated list of web hosts that do (and don''t) play well with Statamic.'
+---
+## Our recommendation
+
+We recommend using [Digital Ocean](https://m.do.co/c/6469827e2269) to host most small to medium Statamic sites. Their servers are fast, inexpensive, and we use them ourselves. _**Full disclosure:** that's an affiliate link but we wouldn't recommend them if it wasn't an excellent option._
+
+Some developers choose to pair Digital Ocean with a tool like [Laravel Forge](/deploying/laravel-forge) or [Ploi](/deploying/ploi), which help you provision servers and handle deployments. However, if you're comfortable doing that yourself, then feel free!
+
+## Community recommendations
+
+The rest of this list is maintained by the community. It's a starting point, not an endorsement — your mileage may vary, and any host that meets the [server requirements](/getting-started/requirements) should run Statamic just fine.
+
+Spot something out of date or have a host to add? Use the [feedback link at the bottom of this page](#got-feedback) to submit a pull request. No affiliate links, please.
+
+### Hosts that play nice
+
+These work well with Statamic out of the box.
+
+- [AWS](https://aws.amazon.com/)
+- [Azure](https://azure.microsoft.com/)
+- [Cyon](https://www.cyon.ch/) - Switzerland
+- [Digital Ocean](https://www.digitalocean.com/)
+- [Digital Ocean App Platform](https://www.digitalocean.com/products/app-platform/)
+- [Digital Pacific](https://www.digitalpacific.com.au/) - Sydney, Australia
+- [Exigo](https://www.exigo.ch/) - Switzerland
+- [fortrabbit](https://www.fortrabbit.com/) - US & EU
+- [Google Cloud Platform](https://cloud.google.com/)
+- [Hetzner Cloud](https://www.hetzner.com/cloud)
+- [HostGator](https://www.hostgator.com/)
+- [Internethelden](https://internethelden.io/) - Germany
+- [Metanet](https://www.metanet.ch) - Switzerland
+- [MyHost](https://myhost.nz/) - New Zealand & Australia
+- [OVH](https://www.ovhcloud.com/) - France & Canada
+- [Vultr](https://www.vultr.com/) - Worldwide
+
+#### Paired with a deployment tool
+
+Some developers pair a server provider with a tool like [Laravel Forge](/deploying/laravel-forge) or [Ploi](/deploying/ploi) to provision servers and handle deployments.
+
+- [Laravel Forge](https://forge.laravel.com/) + [Digital Ocean](https://www.digitalocean.com), [Linode](https://www.linode.com), or [Hetzner Cloud](https://www.hetzner.com/cloud)
+- [Ploi](https://ploi.io) + [Digital Ocean](https://www.digitalocean.com), [Linode](https://www.linode.com), or [Hetzner Cloud](https://www.hetzner.com/cloud)
+
+### Hosts that don't play nice
+
+You should probably avoid these. It doesn't mean it's impossible, but it'll likely require support tickets to enable PHP modules and meet the [server requirements](/getting-started/requirements).
+
+- [Go Daddy](https://godaddy.com) - doesn't meet server requirements
+- [NameCheap](https://namecheap.com)
+- [Rackspace Cloud](https://www.rackspace.com/cloud/) - issues with out-of-sync file timestamps and permissions

--- a/content/collections/pages/requirements.md
+++ b/content/collections/pages/requirements.md
@@ -40,8 +40,4 @@ If you're using Ubuntu (or another variant of Debian), you may find our [Ubuntu 
 
 ## Recommended hosts
 
-We recommend using [Digital Ocean](https://m.do.co/c/6469827e2269) to host most small to medium Statamic sites. Their servers are fast, inexpensive, and we use them ourselves. _**Full disclosure:** that's an affiliate link but we wouldn't recommend them if it wasn't an excellent option._
-
-Some developers choose to pair Digital Ocean with a tool like [Laravel Forge](/deploying/laravel-forge) or [Ploi](/deploying/ploi), which help you provision servers and handle deployments. However, if you're comfortable doing that yourself, then feel free!
-
-We also maintain a user-contributed [Github repo](https://github.com/statamic/hosts) full of other host recommendations.
+Statamic runs on any host that meets the requirements above. See our [recommended hosts](/knowledge-base/recommended-hosts) page for the host we recommend, along with a user-curated list of others that do (and don't) play well with Statamic.

--- a/content/trees/collections/pages.yaml
+++ b/content/trees/collections/pages.yaml
@@ -336,6 +336,8 @@ tree:
       -
         entry: b6c40452-8da0-4f03-a53c-714cc3338b9d
       -
+        entry: 774b3b8f-a328-469f-ab87-04a41e290ddd
+      -
         entry: cd0428cf-2c4a-43b9-8e61-dd8123799ed8
       -
         entry: 0efc0286-bfb1-4d54-8a94-8589b35adf88

--- a/resources/views/deploying.antlers.html
+++ b/resources/views/deploying.antlers.html
@@ -1,6 +1,8 @@
 {{ partial:header }}
 
-<div class="c-icon-grid">
+{{ content }}
+
+<div class="c-icon-grid mt-8">
     <div class="c-icon-grid__item">
         <a href="/deploying/laravel-forge">
             <div class="c-icon-grid__icon">

--- a/resources/views/partials/edit.antlers.html
+++ b/resources/views/partials/edit.antlers.html
@@ -1,5 +1,5 @@
 {{ if {github_edit_url} }}
-<div class="o-entry-content">
+<div class="o-entry-content" id="got-feedback">
     <a href="{{ github_edit_url }}" class="c-feedback-meerkat flex items-center gap-3">
         <div>
             <h2>Got feedback?</h2>


### PR DESCRIPTION
Adds a dedicated, user-curated "Recommended Hosts" knowledge base page, bringing the contents of the [statamic/hosts](https://github.com/statamic/hosts) repo into the docs.

- New `/knowledge-base/recommended-hosts` page with our recommendation (Digital Ocean + Forge/Ploi) up top, followed by the community-curated "play nice" / "don't play nice" lists. Dropped obviously dead/joke entries and stale PHP-version notes from the source.
- Trimmed the duplicated host recommendation on the Requirements page down to a link, so there's no longer two copies to keep in sync.
- Crosslinked the new page from the Deploying page and removed its currently-unused content.
- Added a `#got-feedback` anchor to the feedback partial so the page can deep-link folks to the GitHub edit link for contributions.