### PR TITLE
Add dev environments to recommended hosts page

### DIFF
--- a/content/collections/pages/recommended-hosts.md
+++ b/content/collections/pages/recommended-hosts.md
@@ -59,5 +59,7 @@ For local development, these work well. See [requirements](/getting-started/requ
 - [Laravel Herd](https://herd.laravel.com/)
 - [Laravel Valet](https://laravel.com/docs/valet)
 - [DDEV](https://ddev.com/) - Docker-based PHP development environment
+- [Laravel Homestead](https://laravel.com/docs/homestead)
+- [Vagrant](https://www.vagrantup.com/)
 - [MAMP](https://www.mamp.info/)
 - Jack's iMac

--- a/content/collections/pages/recommended-hosts.md
+++ b/content/collections/pages/recommended-hosts.md
@@ -51,3 +51,13 @@ You should probably avoid these. It doesn't mean it's impossible, but it'll like
 - [Go Daddy](https://godaddy.com) - doesn't meet server requirements
 - [NameCheap](https://namecheap.com)
 - [Rackspace Cloud](https://www.rackspace.com/cloud/) - issues with out-of-sync file timestamps and permissions
+
+### Development environments
+
+For local development, these work well. See [requirements](/getting-started/requirements#development-environments) for the environments we recommend.
+
+- [Laravel Herd](https://herd.laravel.com/)
+- [Laravel Valet](https://laravel.com/docs/valet)
+- [DDEV](https://ddev.com/) - Docker-based PHP development environment
+- [MAMP](https://www.mamp.info/)
+- Jack's iMac


### PR DESCRIPTION
The [recommended hosts page](https://github.com/statamic/docs/pull/1941) unintentionally left out the "Standard Dev Environments" section that existed in the original [statamic/hosts](https://github.com/statamic/hosts) repo. This brings it over.

Dropped Scotch Box (unmaintained since Scotch.io was absorbed into DigitalOcean), and linked out to the Requirements page for the environments we actually recommend. Jack's iMac stays. 😎