### PR TITLE
Add trusted providers section to OAuth documentation

### DIFF
--- a/content/collections/pages/oauth.md
+++ b/content/collections/pages/oauth.md
@@ -175,6 +175,12 @@ To create your own OAuth provider, you should make your own SocialiteProvider-re
 
 Follow the [third party installation steps](#third-party-providers), but skip the Composer bits. You can just keep the classes somewhere in your project.
 
+If you are using a custom provider and trust your own provider that the e-mails coming in are verified, you need to add `trusted_providers` with array of your own provider's handle:
+
+```php
+`trusted_providers => ['my-custom-provider']
+```
+
 ## Customizing user data
 
 After authenticating with the provider, Statamic will try to retrieve the corresponding user, or create one if it doesn't exist. You may customize how it's handled by adding a callback to your `AppServiceProvider`.


### PR DESCRIPTION
In release 6.24.2 and 5.74.1, a new trusted_providers config has been implemented. Since we use custom OAuth2 provider, people couldn't login into the Control Panel without adding the `trusted_providers` array with our provider in it.

Feel free to rewrite the docs, I just wanted to pointed out that this section is missing in the docs.

Related: #1946