### PR TITLE
Fix `inline: break` example

### DIFF
--- a/content/collections/pages/5-to-6.md
+++ b/content/collections/pages/5-to-6.md
@@ -322,7 +322,7 @@ We've simplified the `inline` config option on Bard fields. It is now a toggle, 
 If you were using the `inline: break` option, you should use the new `inline_hard_breaks` option instead:
 
 ```yaml
-inline: inline # [tl! --]
+inline: break # [tl! --]
 inline: true # [tl! ++]
 inline_hard_breaks: true # [tl! ++]
 ```


### PR DESCRIPTION
The upgrade guide says `inline: break` should be changed. However the example uses `inline: inline`.