### PR TITLE
Improve docs agent readiness

### DIFF
--- a/app/Http/Controllers/DocsMarkdownController.php
+++ b/app/Http/Controllers/DocsMarkdownController.php
@@ -32,9 +32,16 @@ class DocsMarkdownController extends Controller
 
         $markdown = $this->appendMdExtensionToInternalLinks($markdown);
 
-        return response($markdown, 200, [
+        $response = response($markdown, 200, [
             'Content-Type' => 'text/markdown; charset=UTF-8',
         ]);
+
+        $response->headers->set('Link', implode(', ', [
+            sprintf('<%s>; rel="canonical"; type="text/html"', url($entry->url())),
+            sprintf('<%s>; rel="describedby"; type="text/plain"', url('/llms.txt')),
+        ]), false);
+
+        return $response;
     }
 
     /**

--- a/app/Http/Controllers/DocsMarkdownController.php
+++ b/app/Http/Controllers/DocsMarkdownController.php
@@ -2,6 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Support\MarkdownUrl;
+use Illuminate\Http\Request;
+use Illuminate\Routing\RedirectController;
+use Illuminate\Routing\Router;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Data;
@@ -11,12 +16,13 @@ class DocsMarkdownController extends Controller
     public function __invoke(string $uri = '')
     {
         $uri = $this->normalizeUri($uri);
+        $entry = Data::findByUri($uri);
 
-        $markdown = Cache::rememberForever("markdown.$uri", function () use ($uri) {
-            $entry = Data::findByUri($uri);
+        if (! $entry) {
+            return $this->redirectLegacyUri($uri);
+        }
 
-            throw_unless($entry, new NotFoundHttpException);
-
+        $markdown = Cache::rememberForever("markdown.$uri", function () use ($entry) {
             return collect([
                 '# '.$entry->value('title'),
                 $entry->value('intro'),
@@ -40,6 +46,33 @@ class DocsMarkdownController extends Controller
         $uri = trim($uri, '/');
 
         return ($uri === '' || $uri === 'index') ? '/' : '/'.$uri;
+    }
+
+    /**
+     * Mirror the redirects used by the HTML docs, but keep internal destinations in
+     * Markdown. This makes legacy links such as `/users.md` redirect to the canonical
+     * `/control-panel/users.md` instead of returning a 404.
+     */
+    private function redirectLegacyUri(string $uri)
+    {
+        $request = Request::create($uri, 'GET');
+        $route = app(Router::class)->getRoutes()->match($request);
+
+        if (ltrim($route->getActionName(), '\\') !== RedirectController::class) {
+            throw new NotFoundHttpException;
+        }
+
+        $request->setRouteResolver(fn () => $route);
+
+        $redirect = app(RedirectController::class)(
+            $request,
+            app(UrlGenerator::class),
+        );
+
+        $destination = $redirect->getTargetUrl();
+        $destination = MarkdownUrl::for($destination) ?? $destination;
+
+        return redirect()->away($destination, $redirect->getStatusCode());
     }
 
     /**

--- a/app/Http/Controllers/DocsMarkdownController.php
+++ b/app/Http/Controllers/DocsMarkdownController.php
@@ -8,10 +8,12 @@ use Statamic\Facades\Data;
 
 class DocsMarkdownController extends Controller
 {
-    public function __invoke(string $uri)
+    public function __invoke(string $uri = '')
     {
+        $uri = $this->normalizeUri($uri);
+
         $markdown = Cache::rememberForever("markdown.$uri", function () use ($uri) {
-            $entry = Data::findByUri('/'.$uri);
+            $entry = Data::findByUri($uri);
 
             throw_unless($entry, new NotFoundHttpException);
 
@@ -29,31 +31,59 @@ class DocsMarkdownController extends Controller
         ]);
     }
 
+    /**
+     * `/index.md` is the conventional Markdown twin of the home page — agents guess it, and
+     * appending `.md` to the root URL isn't possible. Everything else maps straight across.
+     */
+    private function normalizeUri(string $uri): string
+    {
+        $uri = trim($uri, '/');
+
+        return ($uri === '' || $uri === 'index') ? '/' : '/'.$uri;
+    }
+
+    /**
+     * Point internal links at their Markdown twins, so an agent following links from one
+     * `.md` page stays in Markdown instead of falling back into HTML.
+     */
     private function appendMdExtensionToInternalLinks(string $markdown): string
     {
         return preg_replace_callback(
             '/(?<!!)\[([^\]]+)\]\(([^)]+)\)/',
             function ($matches) {
-                $text = $matches[1];
-                $url = $matches[2];
+                [, $text, $url] = $matches;
 
-                if ($this->shouldAppendMdExtension($url)) {
-                    $url .= '.md';
-                }
-
-                return "[$text]($url)";
+                return "[$text]({$this->markdownUrl($url)})";
             },
             $markdown
         );
     }
 
-    private function shouldAppendMdExtension(string $url): bool
+    private function markdownUrl(string $url): string
     {
-        if (preg_match('/^https?:\/\//', $url)) {
+        // Split the fragment/query off first: the extension belongs on the path, so
+        // "/tags/collection#parameters" has to become "/tags/collection.md#parameters".
+        $path = preg_split('/(?=[#?])/', $url, 2);
+        $suffix = $path[1] ?? '';
+        $path = $path[0];
+
+        return $this->shouldAppendMdExtension($path) ? $path.'.md'.$suffix : $url;
+    }
+
+    private function shouldAppendMdExtension(string $path): bool
+    {
+        // Empty path means the link was a bare fragment like "#overview".
+        if ($path === '') {
             return false;
         }
 
-        if (preg_match('/\.[a-z0-9]{2,4}$/i', $url)) {
+        // Absolute URLs, protocol-relative URLs, and non-HTTP schemes (mailto:, tel:).
+        if (preg_match('/^([a-z][a-z0-9+.-]*:|\/\/)/i', $path)) {
+            return false;
+        }
+
+        // Already points at a file.
+        if (preg_match('/\.[a-z0-9]{2,4}$/i', $path)) {
             return false;
         }
 

--- a/app/Http/Controllers/LlmsTxtController.php
+++ b/app/Http/Controllers/LlmsTxtController.php
@@ -2,68 +2,168 @@
 
 namespace App\Http\Controllers;
 
+use App\Support\MarkdownUrl;
 use Illuminate\Support\Facades\Cache;
+use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 
 class LlmsTxtController extends Controller
 {
+    /**
+     * Reference collections, appended after the main docs tree. These hold the bulk of the
+     * site — ~400 entries covering every tag, modifier, fieldtype and variable — and an agent
+     * that can't see them here has no way to discover that `{{ collection }}` exists.
+     */
+    private const REFERENCE_COLLECTIONS = [
+        'tags',
+        'modifiers',
+        'fieldtypes',
+        'variables',
+        'widgets',
+        'tips',
+        'troubleshooting',
+        'resource_apis',
+    ];
+
     public function __invoke()
     {
-        $lines = Cache::rememberForever("llms.txt", function () {
-            $tree = Collection::find('pages')->structure()->trees()->first()->tree();
-            $lines = ['# Statamic Documentation', ''];
-
-            foreach ($tree as $section) {
-                $children = $section['children'] ?? [];
-
-                if (! $children) {
-                    continue;
-                }
-
-                $sectionEntry = Entry::find($section['entry']);
-                $lines[] = '## '.$sectionEntry->value('title');
-
-                $firstChild = Entry::find($children[0]['entry']);
-                if ($firstChild && str_contains($firstChild->slug(), 'overview')) {
-                    if ($intro = $firstChild->value('intro')) {
-                        $lines[] = '> '.str_replace("\n", ' ', $intro);
-                    }
-                }
-
-                $lines[] = '';
-
-                foreach ($children as $child) {
-                    $entry = Entry::find($child['entry']);
-                    if (! $entry) {
-                        continue;
-                    }
-
-                    $url = $entry->url();
-                    if (! $url) {
-                        continue;
-                    }
-
-                    $title = $entry->value('title');
-                    $isExternal = str_starts_with($url, 'http');
-                    $href = $isExternal ? $url : url($url).'.md';
-                    $line = '- ['.$title.']('.$href.')';
-
-                    if ($intro = $entry->value('intro')) {
-                        $line .= ': '.str_replace("\n", ' ', $intro);
-                    }
-
-                    $lines[] = $line;
-                }
-
-                $lines[] = '';
-            }
-
-            return $lines;
-        });
+        $lines = Cache::rememberForever('llms.txt', fn () => $this->build());
 
         return response(implode("\n", $lines), 200, [
             'Content-Type' => 'text/plain; charset=UTF-8',
         ]);
+    }
+
+    private function build(): array
+    {
+        $docsVersion = config('docs.version');
+
+        $lines = [
+            '# Statamic Documentation',
+            '',
+            "> Statamic is a Laravel-powered CMS that stores content in flat files by default. This is the documentation for Statamic {$docsVersion}. Every page listed here is also available as Markdown — the `.md` URLs below return plain Markdown rather than HTML.",
+            '',
+        ];
+
+        foreach ($this->guide() as $line) {
+            $lines[] = $line;
+        }
+
+        foreach (self::REFERENCE_COLLECTIONS as $handle) {
+            foreach ($this->referenceSection($handle) as $line) {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The main docs, following the full depth of the page tree rather than just each
+     * section's immediate children.
+     */
+    private function guide(): array
+    {
+        $tree = Collection::find('pages')->structure()->trees()->first()->tree();
+        $lines = [];
+
+        foreach ($tree as $section) {
+            if (! $children = $section['children'] ?? []) {
+                continue;
+            }
+
+            if (! $sectionEntry = Entry::find($section['entry'])) {
+                continue;
+            }
+
+            $lines[] = '## '.$sectionEntry->value('title');
+
+            // Sections lead with an "overview" child whose intro describes the whole section.
+            $firstChild = Entry::find($children[0]['entry']);
+            if ($firstChild && str_contains($firstChild->slug(), 'overview')) {
+                if ($intro = $firstChild->value('intro')) {
+                    $lines[] = '> '.$this->oneLine($intro);
+                }
+            }
+
+            $lines[] = '';
+
+            foreach ($this->flatten($children) as $entry) {
+                $lines[] = $this->entryLine($entry);
+            }
+
+            $lines[] = '';
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Walk a tree branch to any depth, returning entries in reading order.
+     */
+    private function flatten(array $branch): array
+    {
+        $entries = [];
+
+        foreach ($branch as $node) {
+            $entry = Entry::find($node['entry'] ?? null);
+
+            if ($entry && $entry->published()) {
+                $entries[] = $entry;
+            }
+
+            foreach ($this->flatten($node['children'] ?? []) as $descendant) {
+                $entries[] = $descendant;
+            }
+        }
+
+        return $entries;
+    }
+
+    private function referenceSection(string $handle): array
+    {
+        if (! $collection = Collection::find($handle)) {
+            return [];
+        }
+
+        // "Reference" disambiguates these from the guide sections above, several of which
+        // share a name (the "Tags" guide explains tags; "Tags Reference" lists all 97).
+        $lines = ['## '.$collection->title().' Reference', ''];
+
+        $entries = $collection->queryEntries()
+            ->where('published', true)
+            ->orderBy('title', 'asc')
+            ->get();
+
+        foreach ($entries as $entry) {
+            $lines[] = $this->entryLine($entry);
+        }
+
+        $lines[] = '';
+
+        return $lines;
+    }
+
+    private function entryLine(EntryContract $entry): string
+    {
+        $url = $entry->url();
+
+        // Some tree nodes link off-site (ui.statamic.dev, YouTube). Those have no Markdown
+        // twin, so they're linked as-is.
+        $href = MarkdownUrl::for($url) ?? $url;
+
+        $line = '- ['.$entry->value('title').']('.$href.')';
+
+        if ($description = $entry->value('meta_description')) {
+            $line .= ': '.$this->oneLine($description);
+        }
+
+        return $line;
+    }
+
+    private function oneLine(string $text): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $text) ?? $text);
     }
 }

--- a/app/Http/Controllers/RobotsTxtController.php
+++ b/app/Http/Controllers/RobotsTxtController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class RobotsTxtController extends Controller
+{
+    /**
+     * AI crawlers we name explicitly. The policy is the same as the wildcard group,
+     * but stating it per-agent makes our stance unambiguous to both operators and
+     * agent-readiness scanners. Content-Signal is not inherited from `*`, so any
+     * agent listed here needs the directive repeated in its own group.
+     */
+    private array $aiCrawlers = [
+        'GPTBot',
+        'OAI-SearchBot',
+        'ChatGPT-User',
+        'ClaudeBot',
+        'Claude-User',
+        'Claude-SearchBot',
+        'PerplexityBot',
+        'Google-Extended',
+        'Applebot-Extended',
+        'meta-externalagent',
+        'Bytespider',
+        'CCBot',
+    ];
+
+    public function __invoke()
+    {
+        $version = config('docs.version');
+
+        $lines = [
+            "# Statamic {$version} Documentation",
+            '#',
+            '# Machine-readable index: /llms.txt',
+            '# Every page is also available as Markdown by appending .md to its URL,',
+            '# e.g. /tags/collection.md — far cheaper to read than the HTML.',
+            '',
+            'User-agent: *',
+            'Allow: /',
+            $this->contentSignals(),
+            '',
+        ];
+
+        foreach ($this->aiCrawlers as $crawler) {
+            $lines[] = "User-agent: {$crawler}";
+        }
+
+        $lines[] = 'Allow: /';
+        $lines[] = $this->contentSignals();
+        $lines[] = '';
+        $lines[] = 'Sitemap: '.url('/sitemap.xml');
+        $lines[] = '';
+
+        return response(implode("\n", $lines), 200, [
+            'Content-Type' => 'text/plain; charset=UTF-8',
+        ]);
+    }
+
+    /**
+     * Content Signals (https://contentsignals.org) declare how this content may be used.
+     * The docs are open source, and models knowing Statamic is good for Statamic, so we
+     * permit all three uses.
+     */
+    private function contentSignals(): string
+    {
+        return 'Content-Signal: search=yes, ai-input=yes, ai-train=yes';
+    }
+}

--- a/app/Http/Middleware/ServeMarkdown.php
+++ b/app/Http/Middleware/ServeMarkdown.php
@@ -85,11 +85,17 @@ class ServeMarkdown
     private function prefersMarkdown(Request $request): bool
     {
         $accept = strtolower((string) $request->header('Accept'));
-        $markdown = AcceptHeader::fromString($accept)->get('text/markdown');
+        $header = AcceptHeader::fromString($accept);
 
         // A wildcard Accept header should continue to receive the normal HTML response.
         // Negotiate Markdown only when the client explicitly asks for it and prefers it.
-        return $markdown && $markdown->getQuality() > 0
+        if (! $header->has('text/markdown')) {
+            return false;
+        }
+
+        $markdown = $header->get('text/markdown');
+
+        return $markdown->getQuality() > 0
             && $request->prefers(['text/markdown', 'text/html']) === 'text/markdown';
     }
 }

--- a/app/Http/Middleware/ServeMarkdown.php
+++ b/app/Http/Middleware/ServeMarkdown.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Http\Controllers\DocsMarkdownController;
+use App\Support\MarkdownUrl;
+use Closure;
+use Illuminate\Http\Request;
+use Statamic\Facades\Data;
+use Symfony\Component\HttpFoundation\AcceptHeader;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class ServeMarkdown
+{
+    public function __construct(private DocsMarkdownController $markdown) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->isMethod('GET') && ! $request->isMethod('HEAD')) {
+            return $next($request);
+        }
+
+        $uri = '/'.trim($request->path(), '/');
+
+        if ($uri === '/') {
+            $uri = '';
+        }
+
+        if (! Data::findByUri($uri === '' ? '/' : $uri)) {
+            return $this->handlePotentialDocsRedirect($request, $next($request));
+        }
+
+        $response = $this->prefersMarkdown($request)
+            ? ($this->markdown)($uri)
+            : $next($request);
+
+        $response->setVary('Accept', false);
+
+        if ($request->isMethod('HEAD')) {
+            $response->setContent('');
+        }
+
+        return $response;
+    }
+
+    /**
+     * When a legacy HTML URL redirects to a documentation entry, point clients that asked
+     * for Markdown directly at the destination's Markdown twin. This does not rely on a
+     * particular HTTP client retaining its Accept header while following the redirect.
+     */
+    private function handlePotentialDocsRedirect(Request $request, Response $response): Response
+    {
+        if (! $response instanceof RedirectResponse) {
+            return $response;
+        }
+
+        $destination = $response->getTargetUrl();
+        $path = parse_url($destination, PHP_URL_PATH);
+
+        if (! is_string($path) || ! Data::findByUri($path)) {
+            return $response;
+        }
+
+        $response->setVary('Accept', false);
+
+        if ($this->prefersMarkdown($request)) {
+            $response->setTargetUrl(MarkdownUrl::for($destination) ?? $destination);
+        }
+
+        return $response;
+    }
+
+    private function prefersMarkdown(Request $request): bool
+    {
+        $accept = strtolower((string) $request->header('Accept'));
+        $markdown = AcceptHeader::fromString($accept)->get('text/markdown');
+
+        // A wildcard Accept header should continue to receive the normal HTML response.
+        // Negotiate Markdown only when the client explicitly asks for it and prefers it.
+        return $markdown && $markdown->getQuality() > 0
+            && $request->prefers(['text/markdown', 'text/html']) === 'text/markdown';
+    }
+}

--- a/app/Http/Middleware/ServeMarkdown.php
+++ b/app/Http/Middleware/ServeMarkdown.php
@@ -27,13 +27,24 @@ class ServeMarkdown
             $uri = '';
         }
 
-        if (! Data::findByUri($uri === '' ? '/' : $uri)) {
+        $entry = Data::findByUri($uri === '' ? '/' : $uri);
+
+        if (! $entry) {
             return $this->handlePotentialDocsRedirect($request, $next($request));
         }
 
-        $response = $this->prefersMarkdown($request)
+        $prefersMarkdown = $this->prefersMarkdown($request);
+
+        $response = $prefersMarkdown
             ? ($this->markdown)($uri)
             : $next($request);
+
+        if (! $prefersMarkdown) {
+            $response->headers->set('Link', implode(', ', [
+                sprintf('<%s>; rel="alternate"; type="text/markdown"', MarkdownUrl::for($entry->url())),
+                sprintf('<%s>; rel="describedby"; type="text/plain"', url('/llms.txt')),
+            ]), false);
+        }
 
         $response->setVary('Accept', false);
 

--- a/app/Modifiers/MarkdownUrl.php
+++ b/app/Modifiers/MarkdownUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Modifiers;
+
+use App\Support\MarkdownUrl as MarkdownUrlBuilder;
+use Statamic\Modifiers\Modifier;
+
+class MarkdownUrl extends Modifier
+{
+    /**
+     * Turn a docs URL into the URL of its Markdown twin.
+     */
+    public function index($value, $params)
+    {
+        return MarkdownUrlBuilder::for($value ? (string) $value : null);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,11 +7,13 @@ use App\Markdown\Mermaid\MermaidExtension;
 use App\Markdown\Tabs\TabbedCodeBlockExtension;
 use App\Search\Listeners\SearchEntriesCreatedListener;
 use App\Search\Storybook\StorybookSearchProvider;
+use App\Support\Description;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Markdown;
 use Stillat\DocumentationSearch\Events\SearchEntriesCreated;
 use Torchlight\Engine\CommonMark\Extension as TorchlightExtension;
@@ -49,6 +51,23 @@ class AppServiceProvider extends ServiceProvider
 
         Event::listen(SearchEntriesCreated::class, SearchEntriesCreatedListener::class);
 
+        $this->registerComputedValues();
+
         StorybookSearchProvider::register();
+    }
+
+    /**
+     * A value every collection needs but no blueprint defines. Registering it as a computed
+     * value means one implementation serves Antlers templates ({{ meta_description }}) and
+     * PHP alike ($entry->value('meta_description')).
+     */
+    private function registerComputedValues(): void
+    {
+        $collections = [
+            'pages', 'tags', 'modifiers', 'fieldtypes', 'variables',
+            'widgets', 'tips', 'troubleshooting', 'resource_apis',
+        ];
+
+        Collection::computed($collections, 'meta_description', fn ($entry) => Description::for($entry));
     }
 }

--- a/app/Support/Description.php
+++ b/app/Support/Description.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+use Statamic\Contracts\Entries\Entry;
+
+/**
+ * Derives a human-readable description for an entry.
+ *
+ * Most reference entries (modifiers, variables, resource APIs) have no `intro`, which
+ * left meta descriptions, Open Graph tags and llms.txt entries empty. This falls back
+ * through `intro` → `description` → the first real paragraph of the body so every page
+ * says something useful about itself.
+ */
+class Description
+{
+    private const MAX_LENGTH = 160;
+
+    public static function for(Entry $entry): string
+    {
+        foreach (['intro', 'description'] as $field) {
+            if ($value = $entry->value($field)) {
+                return self::tidy(self::stripInlineMarkdown($value));
+            }
+        }
+
+        return self::tidy(self::firstParagraph((string) $entry->value('content')));
+    }
+
+    /**
+     * Pull the first prose paragraph out of a raw Markdown body.
+     *
+     * Deliberately works on the raw Markdown rather than rendered HTML: these pages are
+     * code-heavy, and rendering first would mean fighting Torchlight's syntax highlighting
+     * markup to get back to plain text.
+     */
+    public static function firstParagraph(string $markdown): string
+    {
+        if (trim($markdown) === '') {
+            return '';
+        }
+
+        $markdown = self::stripBlocks($markdown);
+
+        foreach (preg_split('/\n\s*\n/', $markdown) as $paragraph) {
+            $paragraph = trim($paragraph);
+
+            if ($paragraph === '' || self::isNotProse($paragraph)) {
+                continue;
+            }
+
+            return self::stripInlineMarkdown($paragraph);
+        }
+
+        return '';
+    }
+
+    /**
+     * Remove block-level constructs that never make sense in a description: fenced code,
+     * HTML, and the custom `::tabs` / `:::tip` syntax handled by our CommonMark extensions
+     * in app/Markdown.
+     */
+    private static function stripBlocks(string $markdown): string
+    {
+        $patterns = [
+            '/^```.*?^```/ms',      // fenced code blocks
+            '/^~~~.*?^~~~/ms',      // alternate fence
+            '/^::tabs.*?^::\/tabs/ms', // tabbed code blocks (fully closed)
+            '/^::tab[^\n]*$/m',     // stray tab markers
+            '/^::\/?tabs?[^\n]*$/m',
+            '/^:{3,}[^\n]*$/m',     // hint block delimiters (:::tip, :::warning, :::)
+            // Headings are dropped line-by-line rather than as whole paragraphs: plenty of
+            // pages open with a heading on the line directly above their first prose, with no
+            // blank line between them.
+            '/^#{1,6}[ \t][^\n]*$/m',
+            '/^<[^\n]*>$/m',        // standalone HTML lines
+            '/^\{\{.*?\}\}$/ms',    // Antlers left in content
+        ];
+
+        return preg_replace($patterns, '', $markdown) ?? $markdown;
+    }
+
+    /**
+     * Lines that are structural rather than prose — headings, list items, tables,
+     * blockquotes, images and indented code.
+     */
+    private static function isNotProse(string $paragraph): bool
+    {
+        return (bool) preg_match('/^(#|>|\||[-*+]\s|\d+\.\s|!\[|    |\t)/', $paragraph);
+    }
+
+    private static function stripInlineMarkdown(string $text): string
+    {
+        $replacements = [
+            '/!\[[^\]]*\]\([^)]*\)/' => '',      // images
+            '/\[([^\]]+)\]\([^)]*\)/' => '$1',   // links → their text
+            '/`([^`]+)`/' => '$1',               // inline code
+            '/\*\*([^*]+)\*\*/' => '$1',         // bold
+            '/(?<!\w)[*_]([^*_]+)[*_](?!\w)/' => '$1', // italics
+            '/<[^>]+>/' => '',                   // inline HTML
+        ];
+
+        return preg_replace(array_keys($replacements), array_values($replacements), $text) ?? $text;
+    }
+
+    private static function tidy(string $text): string
+    {
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = trim(preg_replace('/\s+/', ' ', $text) ?? $text);
+
+        // Many paragraphs are lead-ins to a code block ("...use the following Facade:").
+        // The trailing colon dangles once the code is gone.
+        $text = rtrim($text, ':');
+
+        return Str::limit($text, self::MAX_LENGTH, '…', preserveWords: true);
+    }
+}

--- a/app/Support/MarkdownUrl.php
+++ b/app/Support/MarkdownUrl.php
@@ -16,13 +16,24 @@ class MarkdownUrl
             return null;
         }
 
-        // Off-site links (ui.statamic.dev, YouTube) have no Markdown twin.
-        if (str_starts_with($url, 'http')) {
+        // Off-site links and non-HTTP schemes have no Markdown twin.
+        if (preg_match('/^([a-z][a-z0-9+.-]*:|\/\/)/i', $url)) {
             return null;
         }
 
+        [$path, $suffix] = array_pad(preg_split('/(?=[#?])/', $url, 2), 2, '');
+        $path = rtrim($path, '/');
+
         // The home page can't take a ".md" suffix, so it lives at /index.md — which is the
         // convention agents guess anyway.
-        return $url === '/' ? url('/index.md') : url($url).'.md';
+        if ($path === '') {
+            return url('/index.md').$suffix;
+        }
+
+        if (! str_ends_with($path, '.md')) {
+            $path .= '.md';
+        }
+
+        return url($path).$suffix;
     }
 }

--- a/app/Support/MarkdownUrl.php
+++ b/app/Support/MarkdownUrl.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Maps a docs URL to its Markdown twin, served by DocsMarkdownController.
+ *
+ * Deliberately not a computed value: resolving an entry's URL during augmentation
+ * re-enters augmentation through Statamic's redirect resolution and blows the stack.
+ */
+class MarkdownUrl
+{
+    public static function for(?string $url): ?string
+    {
+        if (! $url) {
+            return null;
+        }
+
+        // Off-site links (ui.statamic.dev, YouTube) have no Markdown twin.
+        if (str_starts_with($url, 'http')) {
+            return null;
+        }
+
+        // The home page can't take a ".md" suffix, so it lives at /index.md — which is the
+        // convention agents guess anyway.
+        return $url === '/' ? url('/index.md') : url($url).'.md';
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\ServeMarkdown;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->web(prepend: [ServeMarkdown::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow:

--- a/resources/views/partials/meta.antlers.html
+++ b/resources/views/partials/meta.antlers.html
@@ -1,14 +1,29 @@
-<meta name="description" content="{{ intro | striptags }}">
-<meta property="og:type" content="website" />
-<meta property="og:title" content="{{ title }}" />
-<meta property="og:description" content="{{ intro | striptags }}" />
-<meta property="og:url" content="{{ permalink }}" />
+<link rel="canonical" href="{{ permalink ?? current_url }}">
+{{ if noindex }}
+    <meta name="robots" content="noindex, follow">
+{{ else }}
+    {{# max-snippet:-1 lets answer engines quote a full passage rather than a clipped one. #}}
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
+{{ /if }}
+{{ if id }}
+    {{# Every page has a Markdown twin. It's a fraction of the tokens of the HTML. #}}
+    <link rel="alternate" type="text/markdown" href="{{ url | markdown_url }}" title="Markdown version of this page">
+{{ /if }}
+<meta name="description" content="{{ meta_description | sanitize }}">
+{{ if id }}
+    <meta property="og:type" content="article" />
+{{ else }}
+    <meta property="og:type" content="website" />
+{{ /if }}
+<meta property="og:title" content="{{ title | sanitize }}" />
+<meta property="og:description" content="{{ meta_description | sanitize }}" />
+<meta property="og:url" content="{{ permalink ?? current_url }}" />
 <meta property="og:site_name" content="Statamic {{ config:docs:version }} Docs" />
 <meta property="og:locale" content="en_US" />
 <meta property="og:image" content="{{ config:app:url }}/img/social-placeholder.jpg" />
-<meta property="twitter:title" content="{{ title }}" />
+<meta property="twitter:title" content="{{ title | sanitize }}" />
 <meta property="twitter:card" content="summary" />
 <meta property="twitter:site" content="@statamic" />
 <meta property="twitter:image" content="{{ config:app:url }}/img/social-placeholder.jpg" />
-<meta property="twitter:description" content="{{ intro | striptags }}" />
+<meta property="twitter:description" content="{{ meta_description | sanitize }}" />
 {{ partial:favicons }}

--- a/resources/views/sitemap.antlers.html
+++ b/resources/views/sitemap.antlers.html
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{{ get_content from="6aa5449b-5d90-47de-97e7-82ba5f665250" }}
-  <url>
-    <loc>{{ permalink remove_right="/documentation" }}</loc>
-    <lastmod>{{ last_modified format="Y-m-d" }}</lastmod>
-  </url>
-{{ /get_content }}
 {{ collection from="*" }}
   <url>
     <loc>{{ permalink }}</loc>

--- a/routes/redirects.php
+++ b/routes/redirects.php
@@ -77,6 +77,7 @@ Route::permanentRedirect('tips/localizing-globals', '/knowledge-base/tips/locali
 Route::permanentRedirect('tips/storing-content-in-a-database', '/knowledge-base/tips/storing-content-in-a-database');
 Route::permanentRedirect('tips/storing-users-in-a-database', '/knowledge-base/tips/storing-users-in-a-database');
 Route::permanentRedirect('tips/timezones', '/knowledge-base/tips/timezones');
+Route::permanentRedirect('tips/using-statamic-with-laravel-nightwatch', '/knowledge-base/tips/using-statamic-with-laravel-nightwatch');
 Route::permanentRedirect('tips/excluding-the-control-panel-from-maintenance-mode', '/knowledge-base/tips/excluding-the-control-panel-from-maintenance-mode');
 Route::permanentRedirect('upgrade-guide/3-0-to-3-1', '/getting-started/upgrade-guide/3-0-to-3-1');
 Route::permanentRedirect('upgrade-guide/3-1-to-3-2', '/getting-started/upgrade-guide/3-1-to-3-2');
@@ -119,6 +120,7 @@ Route::permanentRedirect('deploying/digitalocean', '/getting-started/deploying/d
 Route::permanentRedirect('installing/docker', '/getting-started/installing/docker');
 Route::permanentRedirect('email', '/advanced-topics/email');
 Route::permanentRedirect('fields', '/content-modeling/fields');
+Route::permanentRedirect('fieldset', '/content-modeling/fieldsets');
 Route::permanentRedirect('fieldsets', '/content-modeling/fieldsets');
 Route::permanentRedirect('fieldtypes', '/fieldtypes/overview');
 Route::permanentRedirect('forms', '/frontend/forms');
@@ -154,6 +156,7 @@ Route::permanentRedirect('protecting-content', '/frontend/protecting-content');
 Route::permanentRedirect('quick-start-guide', '/getting-started/quick-start-guide');
 Route::permanentRedirect('recent-updates', '/');
 Route::permanentRedirect('relationships', '/content-modeling/relationships');
+Route::permanentRedirect('replicator', '/fieldtypes/replicator');
 Route::permanentRedirect('release-schedule-support-policy', '/knowledge-base/release-schedule-support-policy');
 Route::permanentRedirect('requirements', '/getting-started/requirements');
 Route::permanentRedirect('rest-api', '/frontend/rest-api');
@@ -173,6 +176,7 @@ Route::permanentRedirect('installing/ubuntu', '/getting-started/installing/ubunt
 Route::permanentRedirect('updating', '/getting-started/updating');
 Route::permanentRedirect('upgrade-guide', '/getting-started/upgrade-guide');
 Route::permanentRedirect('users', '/control-panel/users');
+Route::permanentRedirect('utilities', '/control-panel/utilities');
 Route::permanentRedirect('upgrade-guide/v2-to-v3', '/getting-started/upgrade-guide/v2-to-v3');
 Route::permanentRedirect('validation', '/content-modeling/validation');
 Route::permanentRedirect('deploying/vercel', '/getting-started/deploying/vercel');

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,12 +2,14 @@
 
 use App\Http\Controllers\LlmsTxtController;
 use App\Http\Controllers\DocsMarkdownController;
+use App\Http\Controllers\RobotsTxtController;
 use Statamic\Facades\Entry;
 
+Route::get('robots.txt', RobotsTxtController::class);
 Route::get('llms.txt', LlmsTxtController::class);
 Route::get('{any}.md', DocsMarkdownController::class)->where('any', '.*');
 
-Route::statamic('search-results', 'search', ['hide_sidebar' => true]);
+Route::statamic('search-results', 'search', ['hide_sidebar' => true, 'noindex' => true]);
 Route::statamic('sitemap.xml', 'sitemap', ['content_type' => 'xml', 'layout' => 'sitemap']);
 
 Route::get('versions.json', fn () => config('docs.versions'));

--- a/tests/Feature/ServeMarkdownTest.php
+++ b/tests/Feature/ServeMarkdownTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ServeMarkdownTest extends TestCase
+{
+    public function test_wildcard_accept_returns_html(): void
+    {
+        $response = $this->get('/control-panel/users', [
+            'Accept' => '*/*',
+        ]);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/html; charset=utf-8');
+        $this->assertStringContainsString('<!doctype html>', strtolower($response->getContent()));
+    }
+
+    public function test_explicit_markdown_accept_returns_markdown(): void
+    {
+        $response = $this->get('/control-panel/users', [
+            'Accept' => 'text/markdown',
+        ]);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/markdown; charset=UTF-8');
+        $this->assertStringStartsWith('# Users', $response->getContent());
+    }
+
+    public function test_browser_accept_returns_html(): void
+    {
+        $response = $this->get('/control-panel/users', [
+            'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        ]);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/html; charset=utf-8');
+    }
+
+    public function test_html_pages_include_markdown_alternate_link_header(): void
+    {
+        $response = $this->get('/control-panel/users', [
+            'Accept' => 'text/html',
+        ]);
+
+        $response->assertOk();
+        $response->assertHeader('Vary', 'Accept');
+        $this->assertStringContainsString('rel="alternate"; type="text/markdown"', $response->headers->get('Link'));
+    }
+
+    public function test_legacy_url_with_markdown_accept_redirects_to_markdown_twin(): void
+    {
+        $response = $this->get('/users', [
+            'Accept' => 'text/markdown',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertStringEndsWith('/control-panel/users.md', $response->headers->get('Location'));
+    }
+
+    public function test_index_md_serves_home_page(): void
+    {
+        $response = $this->get('/index.md');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/markdown; charset=UTF-8');
+        $this->assertStringStartsWith('# Home', $response->getContent());
+    }
+
+}

--- a/tests/Unit/MarkdownUrlTest.php
+++ b/tests/Unit/MarkdownUrlTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\MarkdownUrl;
+use Tests\TestCase;
+
+class MarkdownUrlTest extends TestCase
+{
+    public function test_maps_docs_path_to_markdown_twin(): void
+    {
+        $this->assertSame(
+            url('/tags/collection.md'),
+            MarkdownUrl::for('/tags/collection')
+        );
+    }
+
+    public function test_preserves_fragment_and_query(): void
+    {
+        $this->assertSame(
+            url('/tags/collection.md#parameters'),
+            MarkdownUrl::for('/tags/collection#parameters')
+        );
+
+        $this->assertSame(
+            url('/tags/collection.md?foo=bar'),
+            MarkdownUrl::for('/tags/collection?foo=bar')
+        );
+    }
+
+    public function test_home_page_uses_index_md(): void
+    {
+        $this->assertSame(
+            url('/index.md'),
+            MarkdownUrl::for('/')
+        );
+    }
+
+    public function test_returns_null_for_external_urls(): void
+    {
+        $this->assertNull(MarkdownUrl::for('https://example.com/docs'));
+        $this->assertNull(MarkdownUrl::for('mailto:hello@example.com'));
+    }
+
+}


### PR DESCRIPTION
Our docs currently don't score that high on Cloudflare's https://isitagentready.com and there is a lot of room for improvement. We already serve pages as markdown when appending `.md` to a URL (basic right now and some undiscoverable) and also have a `llms.txt` file in place (misses a few things). Those can be improved as well as a lot of other changes and improvements (e.g. much more in-depth `robots.txt` file). This PR implements several recommendations and best practices from https://isitagentready.com, https://blog.cloudflare.com/agent-readiness/, and https://blog.cloudflare.com/aeo/.


### Discoverability

- `robots.txt` is now a route instead of a two line static file. It has a `Sitemap:` directive (there wasn't one), Content Signals declaring `search=yes, ai-input=yes, ai-train=yes`, and explicit groups for 12 named AI crawlers.
- Removed a dead lookup from `sitemap.xml`. It opened by fetching and entry ID (6aa5449b...) which doesn't exist anymore.

### Content accessibility

- `llms.txt` went from 128 to 613 entries. It only walked one level deep, so nested pages like `/getting-started/installing/laravel` were dropped and the ~460 reference entries (tags, modifiers, fieldtypes, variables) weren't in there at all. An agent reading it couldn't discover any of it.
- The home page now has a Markdown version at `/index.md`. None before.
- Every page links to its Markdown twin via `<link rel="alternate" type="text/markdown">`, plus `rel="canonical"` and a `robots` tag with `max-snippet:-1` so answer engines can quote a full passage. `/search-results` is `noindex`.

### Meta descriptions

- 225 of 630 entries had no `intro` or `description`, like the modifiers, variables, or
resource API pages. They were emitting empty meta descriptions, empty Open Graph tags and empty `llms.txt` entries.
- There's now a fallback chain (`intro` -> `description` -> first paragraph of the body) that strips code fences, `::tabs`, `:::tip` blocks and inline markdown. It's a computed
value so one implementation covers all templates and also the `llms.txt`.

### Two other bugs fixed

- Link anchors were being mangled in the Markdown output. E.g. `(#update-scripts)` became
  `(#update-scripts.md)`. The `.md` now goes before the fragment.
- An unpublished draft was listed in `llms.txt`. `digitalocean.md` is
  `published: false` but was included in the file. Now correctly filter the entries.