### PR TITLE
Add update scripts information for zero downtime deployments 

### DIFF
--- a/content/collections/tips/configuring-update-scripts.md
+++ b/content/collections/tips/configuring-update-scripts.md
@@ -36,3 +36,12 @@ php please updates:run 3.0
 :::tip
 This is a one-time thing and will be automatically triggered by future Statamic updates.
 :::
+
+### Running update scripts when doing zero downtime deployments 
+
+Since zero downtime deployments typically use a multiple-release directory structure, where each new deployment is a fresh installation of the application, update scripts can be missed. 
+To ensure update scripts are run, add a step to your deployment pipeline that makes a backup of the `composer.lock` file.
+``` shell
+# Backup composer lock file to ensure update scripts are run
+cp composer.lock storage/statamic/updater/composer.lock.bak
+```

--- a/content/collections/tips/zero-downtime-deployments.md
+++ b/content/collections/tips/zero-downtime-deployments.md
@@ -34,6 +34,15 @@ Every deployment has its own timestamped release directory, with a fresh clone o
 
 After a successful deployment, the `current` folder is then symlinked to the latest release. This symlink swap is the secret sauce for zero downtime.
 
+### Ensure update scripts are run 
+
+Since each new deployment is a fresh installation of the application, update scripts can be missed. 
+To ensure update scripts are run, add a step to your deployment pipeline that makes a backup of the `composer.lock` file.
+``` shell
+# Backup composer lock file to ensure update scripts are run
+cp composer.lock storage/statamic/updater/composer.lock.bak
+```
+
 ## Cache storage
 
 Statamic's content management heavily relies on caching, and sometimes it's necessary for the [Stache](/stache) to store absolute file paths in your app's cache. This can lead to deployment errors when users are hitting your frontend, since each release [exists in a separate timestamped folder](#understanding-the-folder-structure).


### PR DESCRIPTION
Added a section to both `configuring-update-scripts.md` and `zero-downtime-deployments.md` explaining that update scripts may be missed during zero downtime deployments and recommending a deployment step to back up the `composer.lock` file. 