### PR TITLE
Generate the sitemap as a static file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /node_modules
 /public/hot
+/public/sitemap.xml
 /public/storage
 /public/vendor/statamic
 /public/build/*

--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use DOMDocument;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+class GenerateSitemap extends Command
+{
+    protected $signature = 'sitemap:generate';
+
+    protected $description = 'Generate the public XML sitemap';
+
+    public function handle(): int
+    {
+        $xml = view('sitemap')->render();
+
+        $this->validateXml($xml);
+
+        File::replace(public_path('sitemap.xml'), $xml);
+
+        $this->info('Generated public/sitemap.xml');
+
+        return self::SUCCESS;
+    }
+
+    private function validateXml(string $xml): void
+    {
+        $previous = libxml_use_internal_errors(true);
+
+        try {
+            $valid = (new DOMDocument)->loadXML($xml, LIBXML_NONET);
+            $errors = libxml_get_errors();
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        if (! $valid) {
+            $message = trim($errors[0]->message ?? 'Unknown XML validation error.');
+
+            throw new RuntimeException("Unable to generate sitemap: {$message}");
+        }
+    }
+}

--- a/tests/Feature/GenerateSitemapTest.php
+++ b/tests/Feature/GenerateSitemapTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use DOMDocument;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class GenerateSitemapTest extends TestCase
+{
+    private string $temporaryPublicPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->temporaryPublicPath = storage_path('framework/testing/public-'.Str::uuid());
+
+        File::ensureDirectoryExists($this->temporaryPublicPath);
+
+        $this->app->usePublicPath($this->temporaryPublicPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->temporaryPublicPath);
+
+        parent::tearDown();
+    }
+
+    public function test_it_generates_a_valid_public_sitemap(): void
+    {
+        $this->artisan('sitemap:generate')
+            ->expectsOutput('Generated public/sitemap.xml')
+            ->assertSuccessful();
+
+        $path = public_path('sitemap.xml');
+
+        $this->assertFileExists($path);
+
+        $document = new DOMDocument;
+
+        $this->assertTrue($document->load($path));
+        $this->assertSame('urlset', $document->documentElement->localName);
+        $this->assertSame('http://www.sitemaps.org/schemas/sitemap/0.9', $document->documentElement->namespaceURI);
+        $this->assertGreaterThan(0, $document->getElementsByTagName('url')->length);
+    }
+}


### PR DESCRIPTION
This adds a dedicated `sitemap:generate` command that renders the existing Antlers sitemap template and writes it to `public/sitemap.xml`.
Right now, our docs exclude the `/sitemap.xml` route from static caching and renders it dynamically on _every_ request (adding unnecessary overhead). Adding it to be included in the static cache won't work since it's getting cached as a `.html` with a response header of `text/html` messing things up. 

This generates a static sitemap during deployment making the request and response way faster but also retains the dynamic generation locally for testing. Adds it to `.gitignore` as well since we want a fresh sitemap on deploy.