### PR TITLE
Agent discovery tweaks

### DIFF
--- a/app/Http/Middleware/ServeMarkdown.php
+++ b/app/Http/Middleware/ServeMarkdown.php
@@ -43,10 +43,10 @@ class ServeMarkdown
             $response->headers->set('Link', implode(', ', [
                 sprintf('<%s>; rel="alternate"; type="text/markdown"', MarkdownUrl::for($entry->url())),
                 sprintf('<%s>; rel="describedby"; type="text/plain"', url('/llms.txt')),
-            ]), false);
+            ]));
         }
 
-        $response->setVary('Accept', false);
+        $this->addAcceptToVary($response);
 
         if ($request->isMethod('HEAD')) {
             $response->setContent('');
@@ -73,13 +73,21 @@ class ServeMarkdown
             return $response;
         }
 
-        $response->setVary('Accept', false);
+        $this->addAcceptToVary($response);
 
         if ($this->prefersMarkdown($request)) {
             $response->setTargetUrl(MarkdownUrl::for($destination) ?? $destination);
         }
 
         return $response;
+    }
+
+    private function addAcceptToVary(Response $response): void
+    {
+        $response->setVary(array_values(array_unique([
+            ...$response->getVary(),
+            'Accept',
+        ])));
     }
 
     private function prefersMarkdown(Request $request): bool

--- a/app/Http/Middleware/ServeMarkdown.php
+++ b/app/Http/Middleware/ServeMarkdown.php
@@ -21,6 +21,17 @@ class ServeMarkdown
             return $next($request);
         }
 
+        if (str_ends_with($request->path(), '.md')) {
+            $uri = substr($request->path(), 0, -3);
+            $response = ($this->markdown)($uri);
+
+            if ($request->isMethod('HEAD')) {
+                $response->setContent('');
+            }
+
+            return $response;
+        }
+
         $uri = '/'.trim($request->path(), '/');
 
         if ($uri === '/') {

--- a/resources/views/partials/meta.antlers.html
+++ b/resources/views/partials/meta.antlers.html
@@ -26,4 +26,5 @@
 <meta property="twitter:site" content="@statamic" />
 <meta property="twitter:image" content="{{ config:app:url }}/img/social-placeholder.jpg" />
 <meta property="twitter:description" content="{{ meta_description | sanitize }}" />
+{{ partial:structured_data }}
 {{ partial:favicons }}

--- a/resources/views/partials/structured_data.antlers.html
+++ b/resources/views/partials/structured_data.antlers.html
@@ -1,0 +1,46 @@
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "Organization",
+            "@id": "https://statamic.com/#organization",
+            "name": "Statamic",
+            "url": "https://statamic.com/"
+        },
+        {
+            "@type": "WebSite",
+            "@id": "{{ config:app:url }}/#website",
+            "url": "{{ config:app:url }}/",
+            "name": "Statamic {{ config:docs:version }} Documentation",
+            "inLanguage": "en",
+            "publisher": {
+                "@id": "https://statamic.com/#organization"
+            }
+        }{{ if id }}{{ unless url == '/' }},
+        {
+            "@type": "TechArticle",
+            "@id": "{{ permalink }}#article",
+            "url": "{{ permalink }}",
+            "headline": {{ title | json }},
+            "description": {{ meta_description | json }},
+            "image": "{{ config:app:url }}/img/social-placeholder.jpg",
+            "inLanguage": "en",
+            "version": "{{ config:docs:version }}",
+            "mainEntityOfPage": {
+                "@type": "WebPage",
+                "@id": "{{ permalink }}#webpage"
+            },
+            "isPartOf": {
+                "@id": "{{ config:app:url }}/#website"
+            },
+            "author": {
+                "@id": "https://statamic.com/#organization"
+            },
+            "publisher": {
+                "@id": "https://statamic.com/#organization"
+            }
+        }{{ /unless }}{{ /if }}
+    ]
+}
+</script>

--- a/tests/Feature/ServeMarkdownTest.php
+++ b/tests/Feature/ServeMarkdownTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Http\Middleware\ServeMarkdown;
+use Illuminate\Http\Request;
 use Tests\TestCase;
 
 class ServeMarkdownTest extends TestCase
@@ -49,6 +51,25 @@ class ServeMarkdownTest extends TestCase
         $this->assertStringContainsString('rel="alternate"; type="text/markdown"', $response->headers->get('Link'));
     }
 
+    public function test_cached_headers_are_not_duplicated(): void
+    {
+        $request = Request::create('/control-panel/users', server: [
+            'HTTP_ACCEPT' => 'text/html',
+        ]);
+
+        $response = app(ServeMarkdown::class)->handle($request, fn () => response('cached', headers: [
+            'Link' => '<https://example.com/stale>; rel="alternate"',
+            'Vary' => 'Accept',
+        ]));
+
+        $link = $response->headers->get('Link');
+
+        $this->assertStringNotContainsString('example.com/stale', $link);
+        $this->assertSame(1, substr_count($link, 'rel="alternate"'));
+        $this->assertSame(1, substr_count($link, 'rel="describedby"'));
+        $this->assertSame(['Accept'], $response->getVary());
+    }
+
     public function test_legacy_url_with_markdown_accept_redirects_to_markdown_twin(): void
     {
         $response = $this->get('/users', [
@@ -67,5 +88,4 @@ class ServeMarkdownTest extends TestCase
         $response->assertHeader('Content-Type', 'text/markdown; charset=UTF-8');
         $this->assertStringStartsWith('# Home', $response->getContent());
     }
-
 }

--- a/tests/Feature/ServeMarkdownTest.php
+++ b/tests/Feature/ServeMarkdownTest.php
@@ -86,6 +86,7 @@ class ServeMarkdownTest extends TestCase
 
         $response->assertOk();
         $response->assertHeader('Content-Type', 'text/markdown; charset=UTF-8');
+        $response->assertHeaderMissing('Set-Cookie');
         $this->assertStringStartsWith('# Home', $response->getContent());
     }
 }


### PR DESCRIPTION
Follow up to the recent agent readiness and AEO improvements.

- Prevent duplicate `Link` and `Vary: Accept` headers.
- Make direct `.md` responses stateless by avoiding unnecessary session and XSRF cookies.
- Add JSON-LD structured data describing Statamic, the documentation website, and individual documentation pages as `TechArticle` entries.