### PR TITLE
Add Blade syntax for locales rendering

### DIFF
--- a/content/collections/tags/locales.md
+++ b/content/collections/tags/locales.md
@@ -100,11 +100,13 @@ Loop through in each locale to get URLs to translated versions of an entry or ta
 </ul>
 ```
 ::tab blade
+```blade
 <ul>
 <s:locales>
   <li><a href="{{ $locale['permalink'] }}">View in {{ $locale['name'] }}</a></li>
 </s:locales>
 </ul>
+```
 ::
 
 ### Targeting a locale {#targeting}


### PR DESCRIPTION
Fixes bad rendering of Blade example on locales tag page.

https://statamic.dev/tags/locales#iterating-over-locales

<img width="809" height="318" alt="image" src="https://github.com/user-attachments/assets/64f973d6-3402-4fcc-a5b2-c40f617317eb" />
