### PR TITLE
Modify middleware to include Content Security Policy

### DIFF
--- a/content/collections/tips/content-security-policy.md
+++ b/content/collections/tips/content-security-policy.md
@@ -29,19 +29,13 @@ The simplest way to do this is to add a `meta` tag to your `head`.
 You may also opt to use a middleware to add a header. If you do this, you'll want to prevent applying it to Control Panel routes, since Statamic needs to be able to run inline JavaScript. You can add it to the `web` middleware group, which your front-end will use but the Control Panel won't.
 
 ```php
-// app/Http/Kernel.php [tl! focus]
+// app/bootstrap/app.php [tl! focus]
 
-protected $middlewareGroups = [ // [tl! focus]
-    'web' => [ // [tl! focus]
-        \App\Http\Middleware\EncryptCookies::class,
-        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-        \Illuminate\Session\Middleware\StartSession::class,
-        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-        \App\Http\Middleware\VerifyCsrfToken::class,
-        \Illuminate\Routing\Middleware\SubstituteBindings::class,
-        \App\Http\Middleware\ContentSecurityPolicy::class, // [tl! ++ focus]
-    ], // [tl! focus]
-]; // [tl! focus]
+->withMiddleware(function (Middleware $middleware) {
+            $middleware->web(append: [ // [tl! ++ focus]
+                \App\Http\Middleware\ContentSecurityPolicy::class, // [tl! ++ focus]
+            ]); // [tl! ++ focus]
+        })
 ```
 ```php
 <?php // app/Http/Middleware/ContentSecurityPolicy.php

--- a/content/collections/tips/content-security-policy.md
+++ b/content/collections/tips/content-security-policy.md
@@ -32,10 +32,10 @@ You may also opt to use a middleware to add a header. If you do this, you'll wan
 // app/bootstrap/app.php [tl! focus]
 
 ->withMiddleware(function (Middleware $middleware) {
-            $middleware->web(append: [ // [tl! ++ focus]
-                \App\Http\Middleware\ContentSecurityPolicy::class, // [tl! ++ focus]
-            ]); // [tl! ++ focus]
-        })
+    $middleware->web(append: [ // [tl! ++ focus]
+        \App\Http\Middleware\ContentSecurityPolicy::class, // [tl! ++ focus]
+    ]); // [tl! ++ focus]
+})
 ```
 ```php
 <?php // app/Http/Middleware/ContentSecurityPolicy.php


### PR DESCRIPTION
Updated middleware configuration to add Content Security Policy to the web middleware group.

This is my first of doing something like this so I hope i have done it right, when I tried to do this I could not find the Kernel file and this is the reason for my update.

I am not sure if I understood the [tl! focus] correctly.