### PR TITLE
Document v6.30.0

### DIFF
--- a/content/collections/fieldtypes/icon.md
+++ b/content/collections/fieldtypes/icon.md
@@ -19,6 +19,12 @@ options:
     type: string
     description: 'Set the default option key. Default: none.'
     required: false
+  -
+    id: iA4enf0t
+    name: mode
+    type: string
+    description: 'Choose between `default` (dropdown) and `compact` (icon picker) UI modes. Default: `default`.'
+    required: false
 ---
 ## Overview
 
@@ -64,4 +70,16 @@ Icon::register('heroicons', base_path('resources/heroicons')); // [tl! ++]
   field:
     type: icon
     set: heroicons # [tl! ++]
+```
+
+## UI Mode
+
+By default, the Icon field displays a searchable dropdown. Setting `mode` to `compact` swaps this out for a single icon-only button that opens a modal picker, saving vertical space in your publish forms.
+
+```yaml
+-
+  handle: favourite_icon
+  field:
+    type: icon
+    mode: compact # [tl! ++]
 ```

--- a/content/collections/pages/building-an-addon.md
+++ b/content/collections/pages/building-an-addon.md
@@ -581,6 +581,34 @@ public function bootAddon()
 
 Your addon's settings page will show up in the Control Panel under **Tools -> Addons**. Pretty convenient.
 
+You can also pass a closure to `registerSettingsBlueprint()`, which will only be evaluated when the blueprint is actually needed. This is handy if building the blueprint is expensive, or requires services that aren't available at boot time.
+
+```php
+public function bootAddon()
+{
+    $this->registerSettingsBlueprint(function () {
+        return [
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'display' => __('API'),
+                            'fields' => [
+                                [
+                                    'handle' => 'api_key',
+                                    'field' => ['type' => 'text', 'display' => 'API Key', 'validate' => 'required'],
+                                ],
+                                // ...
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    });
+}
+```
+
 You can even reference config options (and by extension environment variables) in your settings blueprint using Antlers, like so: `{{ config:app:url }}`.
 
 Settings are stored as YAML files in `resources/addons` by default, but can be moved to the database if you prefer. Just run the `php please install:eloquent-driver` command and you're all set.


### PR DESCRIPTION
This pull request documents the new features and improvements from [v6.30.0](https://github.com/statamic/cms/releases/tag/v6.30.0).

- Documented lazy (closure-based) registration for addon settings blueprints — statamic/cms#15286
- Documented `compact` mode for the icon fieldtype — statamic/cms#15287