### PR TITLE
Document Blade Components within Antlers

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,12 +11,14 @@ use App\Support\Description;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\DescriptionList\DescriptionListExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Markdown;
 use Stillat\DocumentationSearch\Events\SearchEntriesCreated;
-use Torchlight\Engine\CommonMark\Extension as TorchlightExtension;
+use Torchlight\Engine\CommonMark\CodeBlockRenderer;
+use Torchlight\Engine\Engine;
 use Torchlight\Engine\Options as TorchlightOptions;
 
 class AppServiceProvider extends ServiceProvider
@@ -41,12 +43,13 @@ class AppServiceProvider extends ServiceProvider
         if (! app()->runningConsoleCommand('search:update')) {
             TorchlightOptions::setDefaultOptionsBuilder(fn () => TorchlightOptions::fromArray(config('torchlight.options')));
 
-            $extension = new TorchlightExtension(config('torchlight.theme'));
-            $extension
-                ->renderer()
+            $engine = new Engine;
+            $engine->getEnvironment()->grammar('antlers', resource_path('syntaxes/antlers.json'));
+
+            $renderer = (new CodeBlockRenderer(config('torchlight.theme'), $engine))
                 ->setDefaultGrammar(config('torchlight.options.defaultLanguage'));
 
-            Markdown::addExtension(fn () => $extension);
+            Markdown::addRenderer(fn () => [FencedCode::class, $renderer, 10]);
         }
 
         Event::listen(SearchEntriesCreated::class, SearchEntriesCreatedListener::class);

--- a/content/collections/pages/antlers-cheat-sheet.md
+++ b/content/collections/pages/antlers-cheat-sheet.md
@@ -253,6 +253,8 @@ The one-liners:
 | Include a view | `{{ partial:footer }}` |
 | Include one that might not exist | `{{ partial:if_exists src="blog/card" }}` |
 | Pass data to a partial | `{{ partial:blog/card mode="stacked" }}` |
+| Render a component | `<x-alert type="warning" />` |
+| Pass a variable to a component | `<x-alert :title="page_title" />` |
 | Render everything pushed onto a stack | `{{ stack:scripts }}` |
 
 Some helpful things you may need when building your frontend:
@@ -295,7 +297,7 @@ Some helpful things you may need when building your frontend:
 {{ /section:footer }}
 ```
 
-More: [partials](/frontend/antlers#partials), [slots](/frontend/antlers#slots), [stacks](/frontend/antlers#stacks), [section & yield](/frontend/antlers#section--yield).
+More: [partials](/frontend/antlers#partials), [partial slots](/frontend/antlers#slots), [components](/frontend/antlers-components), [stacks](/frontend/antlers#stacks), [section & yield](/frontend/antlers#section--yield).
 
 ## Escaping and preventing parsing
 

--- a/content/collections/pages/antlers-components.md
+++ b/content/collections/pages/antlers-components.md
@@ -1,0 +1,245 @@
+---
+id: 083c717b-545c-45be-a65b-67faf1aa886f
+blueprint: page
+title: 'Antlers Components'
+intro: 'Build reusable components with Antlers, render existing Laravel Blade components, and use HTML-style syntax for Statamic Tags.'
+related_entries:
+  - d37b2af2-f2bf-493a-9345-7087fb5929ce
+  - 0c54fe7c-c87a-4812-b76e-48f16cf08e0d
+  - c7816387-ebc4-4204-b5f2-8e7073a4db8b
+---
+## Overview
+
+Components are reusable, self-contained chunks of interface, such as callouts, cards, buttons, layouts, or whatever else you keep copying and pasting around your site. Antlers can render [Laravel Blade components](https://laravel.com/docs/13.x/blade#components), and anonymous components can be written with Antlers itself.
+
+That gives you two closely related flavors of angle-bracket syntax:
+
+| Syntax | What it renders |
+| --- | --- |
+| `<x-callout />` | A Laravel component class or anonymous component view. The view may use Blade or Antlers. |
+| `<s:collection:blog>...</s:collection:blog>` | A Statamic [Tag](/tags) using component-style syntax. |
+| `{{ collection:blog }}...{{ /collection:blog }}` | The same Statamic Tag using classic Antlers syntax. |
+
+:::tip
+[Partials](/frontend/antlers#partials) inherit the current Antlers scope and are perfect for straightforward includes. Components have their own scope and explicitly receive data through props, the Cascade, and slots.
+:::
+
+## Creating a component
+
+Anonymous components live in `resources/views/components`. Give the view an `.antlers.html` extension to build it with Antlers:
+
+```antlers
+{{# resources/views/components/callout.antlers.html #}}
+@props([
+    'type' => 'info',
+    'title' => 'Heads up!' | upper,
+])
+
+<aside {{ attributes.merge([
+    'class' => 'callout callout--' + type,
+]) }}>
+    <h2>{{ title }}</h2>
+
+    {{ if slot | has_actual_content }}
+        <div>{{ slot }}</div>
+    {{ /if }}
+</aside>
+```
+
+Render it from any Antlers template with an `x-` tag. Paired components receive everything between their tags as the default `slot`:
+
+```antlers
+<x-callout class="mt-8">
+    Save your work before continuing.
+</x-callout>
+```
+
+Components without slot content may self-close:
+
+```antlers
+<x-callout type="warning" title="Back up first" />
+```
+
+Components in subdirectories use dot notation. For example, `resources/views/components/menu/item.antlers.html` becomes `<x-menu.item />`.
+
+:::tip
+**[Blade components](https://laravel.com/docs/blade#components) work, too!** Use them from Antlers without rewriting anything. Blade and Antlers components may even nest inside each other like one big, happy template-language family.
+:::
+
+## Props
+
+The `@props` directive defines the data your component expects. Values with named keys provide defaults, and those defaults are Antlers expressions, not PHP. That means variables, operators, and modifiers like `upper` are all fair game, if that's your style.
+
+```antlers
+@props([
+    'type' => 'info',
+    'title' => 'Heads up!' | upper,
+])
+```
+
+Literal attributes pass strings. Prefix an attribute with `:` to resolve its value from the Antlers scope, or use `:$variable` when the prop and variable share a name:
+
+```antlers
+{{ page_title = 'Back up first' }}
+{{ type = 'warning' }}
+
+<x-callout :title="page_title" :$type />
+```
+
+These are Antlers' [usual parameter rules](/frontend/antlers#tag-parameters), even when the component itself is written in Blade.
+
+## Attributes
+
+Attributes not declared as props are collected in the `attributes` bag. Render the bag directly, or call its Laravel methods with Antlers' dot syntax:
+
+```antlers
+<aside {{ attributes.merge([
+    'class' => 'callout callout--' + type,
+]) }}>
+    ...
+</aside>
+```
+
+The `merge` method adds the component's default attributes while preserving those passed by the caller. Class names are combined, so our earlier `class="mt-8"` joins the callout classes instead of booting them out of the club.
+
+## Slots
+
+The `slot` variable contains the component's unnamed content. Use the `has_actual_content` modifier when whitespace and HTML comments alone should count as empty:
+
+```antlers
+{{ if slot | has_actual_content }}
+    <div>{{ slot }}</div>
+{{ /if }}
+```
+
+The closely related `is_string` modifier is available when you need to distinguish an ordinary string from a slot object or another value:
+
+```antlers
+{{ if value | is_string }}
+    {{ value }}
+{{ /if }}
+```
+
+### Named slots
+
+Use `<x-slot:name>` to send content to a named slot:
+
+```antlers
+<x-panel>
+    <x-slot:heading class="text-xl">
+        Fresh from the blog
+    </x-slot:heading>
+
+    The latest dispatches from our crew.
+</x-panel>
+```
+
+The component receives the slot as a variable. Any attributes on the slot are available through its own `attributes` bag:
+
+```antlers
+{{# resources/views/components/panel.antlers.html #}}
+<section>
+    <header {{ heading.attributes }}>{{ heading }}</header>
+    <div>{{ slot }}</div>
+</section>
+```
+
+## Scope
+
+A component does not inherit the Antlers variables or Cascade data around it. Variables created inside the component do not leak out, either. Pass values as props when they are part of the component's public API.
+
+Slot content is the intentional exception. It is evaluated in the caller's scope, so variables available where you invoke the component remain available inside its default and named slots.
+
+### Cascade data
+
+Use `@cascade` when a component needs data from Statamic's [Cascade](/data-inheritance). Pass a list to import only the values you need. Values listed without defaults are required; a named key may provide a fallback:
+
+```antlers
+@cascade([
+    'title',
+    'eyebrow' => 'Latest',
+])
+
+<h2>{{ title }}</h2>
+<p>{{ eyebrow }}</p>
+```
+
+Omit the arguments to import the entire Cascade:
+
+```antlers
+@cascade
+```
+
+Pulling in everything is convenient, but selecting values keeps the component's dependencies much easier to spot six months from now.
+
+### Sharing parent props
+
+The `@aware` directive lets a nested component consume props explicitly passed to an ancestor component. Here, the menu item picks up the menu's `tone`:
+
+```antlers
+{{# resources/views/components/menu.antlers.html #}}
+@props([
+    'tone' => 'light'
+])
+
+<nav class="menu menu--{{ tone }}">
+    {{ slot }}
+</nav>
+```
+
+```antlers
+{{# resources/views/components/menu/item.antlers.html #}}
+@aware([
+    'tone' => 'light'
+])
+
+<a class="menu__item menu__item--{{ tone }}">{{ slot }}</a>
+```
+
+```antlers
+<x-menu tone="dark">
+    <x-menu.item>Docs</x-menu.item>
+</x-menu>
+```
+
+Like `@props`, the values passed to `@aware` are Antlers expressions. Providing a fallback keeps the nested component useful when it appears outside its usual parent.
+
+### Escaping directives
+
+If you need any of these directives to appear as literal text, add another `@`:
+
+```antlers
+@@props(['example'])
+@@aware(['example'])
+@@cascade
+```
+
+This renders `@props(['example'])`, `@aware(['example'])`, and `@cascade` without evaluating them.
+
+## Component-style Statamic Tags
+
+Statamic Tags may also use HTML-like syntax in Antlers. Prefix the Tag with either `s:` or `statamic:` and otherwise use it as normal:
+
+```antlers
+<s:collection:pages limit="3">
+    <a href="{{ url }}">{{ title }}</a>
+</s:collection:pages>
+```
+
+This is equivalent to classic Antlers syntax:
+
+```antlers
+{{ collection:pages limit="3" }}
+    <a href="{{ url }}">{{ title }}</a>
+{{ /collection:pages }}
+```
+
+Parameters still follow Antlers rules, including dynamic values and shorthand:
+
+```antlers
+<s:collection :from="collection_handle" :$limit>
+    <a href="{{ url }}">{{ title }}</a>
+</s:collection>
+```
+
+You may use `s-` and `statamic-` prefixes instead if dashes feel more HTML-ish, and Tags without enclosed content may self-close. This syntax still invokes a Statamic Tag; it does not look for a component view in `resources/views/components`.

--- a/content/collections/pages/antlers.md
+++ b/content/collections/pages/antlers.md
@@ -1245,6 +1245,11 @@ Now you can define the context of the named slot using the `slot:name` tag forma
   </a>
 {{ /partial:modal }}
 ```
+
+### Components
+
+Components are reusable, isolated chunks of UI with props, attribute bags, and slots. Antlers can render existing Laravel Blade components, and you can author anonymous components with Antlers itself. Head over to [Antlers Components](/frontend/antlers-components) to learn more.
+
 ### Stacks
 
 Antlers allows you to push template code to a "stack" which can be rendered somewhere else in your layout (most commonly) or another view. This can be particularly useful for specifying any JavaScript libraries required by your child views:

--- a/content/collections/pages/blade.md
+++ b/content/collections/pages/blade.md
@@ -163,7 +163,7 @@ Under the hood, this is syntactic sugar for creating an Antlers partial and does
 
 ## Using Antlers Blade components
 
-Despite the name, Antlers Blade Components are a Blade-only feature that allows you to use existing tags inside your Blade templates using a custom tag syntax. For example, you can gather all entries from a "pages" collection using the [collection](/tags/collection) tag like so:
+Antlers Blade Components allow you to use existing tags inside your Blade templates with a custom tag syntax. The same component-style syntax also works [inside Antlers templates](/frontend/antlers-components#component-style-statamic-tags). For example, you can gather all entries from a "pages" collection using the [collection](/tags/collection) tag like so:
 
 ```blade
 <s:collection:pages>

--- a/content/trees/collections/pages.yaml
+++ b/content/trees/collections/pages.yaml
@@ -175,6 +175,8 @@ tree:
       -
         entry: 0c54fe7c-c87a-4812-b76e-48f16cf08e0d
       -
+        entry: 083c717b-545c-45be-a65b-67faf1aa886f
+      -
         entry: c7816387-ebc4-4204-b5f2-8e7073a4db8b
       -
         entry: 74c47654-8c47-49b1-a616-ed940ce19977

--- a/content/trees/navigation/docs.yaml
+++ b/content/trees/navigation/docs.yaml
@@ -146,6 +146,9 @@ tree:
         entry: d37b2af2-f2bf-493a-9345-7087fb5929ce
         title: 'Antlers Templates'
       -
+        id: ff6cfc92-2cb1-49c8-911a-678a58d02e04
+        entry: 083c717b-545c-45be-a65b-67faf1aa886f
+      -
         id: 40ef0b25-0f5e-4523-a527-52a099838d09
         entry: c7816387-ebc4-4204-b5f2-8e7073a4db8b
       -

--- a/resources/syntaxes/antlers.json
+++ b/resources/syntaxes/antlers.json
@@ -1,0 +1,666 @@
+{
+    "comment": "Local override of the Antlers grammar bundled with phiki/phiki for Torchlight.",
+    "name": "Antlers (Statamic Syntax)",
+    "fileTypes": [
+        "antlers.html",
+        "antlers.php",
+        "antlers.xml",
+        "html",
+        "htm",
+        "xhtml"
+    ],
+    "scopeName": "text.html.statamic",
+    "injections": {
+        "text.html.statamic - (meta.embedded | meta.tag), L:((text.html.statamic meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))": {
+            "patterns": [
+                {
+                    "include": "#statamic-comments"
+                },
+                {
+                    "include": "#antlers-tags"
+                },
+                {
+                    "include": "#php-tag"
+                }
+            ]
+        },
+        "text.html.statamic - (meta.embedded | meta.tag | comment.block.html | comment.block.statamic), L:(text.html.statamic meta.tag - (comment.block.statamic | meta.embedded.statamic | comment.block.html))": {
+            "patterns": [
+                {
+                    "comment": "This is set to use XHTML standards, but you can change that by changing .strict to .basic for HTML standards",
+                    "include": "text.html.basic"
+                }
+            ]
+        },
+        "text.html.statamic": {
+            "patterns": [
+                {
+                    "include": "#antlers-directives"
+                },
+                {
+                    "include": "#statamic-comments"
+                },
+                {
+                    "include": "#antlers-tags"
+                }
+            ]
+        }
+    },
+    "patterns": [
+        {
+            "include": "#antlers-directives"
+        },
+        {
+            "include": "#php-tag"
+        },
+        {
+            "include": "#statamic-comments"
+        },
+        {
+            "include": "#frontMatter"
+        },
+        {
+            "include": "#antlers-tags"
+        }
+    ],
+    "repository": {
+        "php-tag": {
+            "patterns": [
+                {
+                    "begin": "<\\?(?i:php|=)?(?![^?]*\\?>)",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.section.embedded.begin.statamic"
+                        }
+                    },
+                    "end": "(\\?)>",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.embedded.end.statamic"
+                        },
+                        "1": {
+                            "name": "source.php"
+                        }
+                    },
+                    "name": "meta.embedded.block.statamic",
+                    "contentName": "source.php",
+                    "patterns": [
+                        {
+                            "include": "source.php"
+                        }
+                    ]
+                },
+                {
+                    "begin": "(?<!@){{([\\$\\?]\\s?)",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.section.embedded.begin.statamic"
+                        }
+                    },
+                    "end": "(\\s?)[\\$\\?]}}",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.embedded.end.statamic"
+                        },
+                        "1": {
+                            "name": "source.php"
+                        }
+                    },
+                    "name": "meta.embedded.line.statamic",
+                    "contentName": "source.php",
+                    "patterns": [
+                        {
+                            "include": "source.php"
+                        }
+                    ]
+                },
+                {
+                    "begin": "<\\?(?i:php|=)?",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.section.embedded.begin.statamic"
+                        }
+                    },
+                    "end": "(\\?)>",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.section.embedded.end.statamic"
+                        },
+                        "1": {
+                            "name": "source.php"
+                        }
+                    },
+                    "name": "meta.embedded.line.statamic",
+                    "contentName": "source.php",
+                    "patterns": [
+                        {
+                            "include": "source.php"
+                        }
+                    ]
+                }
+            ]
+        },
+        "frontMatter": {
+            "begin": "\\A-{3}\\s*$",
+            "contentName": "meta.embedded.block.frontmatter",
+            "patterns": [
+                {
+                    "include": "source.yaml"
+                }
+            ],
+            "end": "(^|\\G)-{3}|\\.{3}\\s*$"
+        },
+        "statamic-comments": {
+            "begin": "{{#",
+            "end": "#}}",
+            "name": "comment.block.statamic"
+        },
+        "antlers-tags": {
+            "begin": "(?<!@){{(?!\\$)(\\s?)",
+            "end": "(\\s?)}}",
+            "name": "meta.embedded.block.statamic",
+            "patterns": [
+                {
+                    "include": "#statamic-comments"
+                },
+                {
+                    "include": "#php-tag"
+                },
+                {
+                    "include": "#antlers-conditionals"
+                },
+                {
+                    "include": "#antlers-expression"
+                }
+            ]
+        },
+        "antlers-conditionals": {
+            "match": "(?<!:)(/?else|/?elseif|/?if|/?unless|endif|endunless|unlesselse|stop)",
+            "name": "keyword.control.statamic"
+        },
+        "string-double-quoted": {
+            "begin": "\"",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.statamic"
+                }
+            },
+            "end": "\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.statamic"
+                }
+            },
+            "name": "string.quoted.double.statamic",
+            "patterns": [
+                {
+                    "begin": "(?<!@){(\\s?)",
+                    "end": "(\\s?)}",
+                    "patterns": [
+                        {
+                            "include": "#antlers-expression"
+                        }
+                    ]
+                }
+            ]
+        },
+        "string-single-quoted": {
+            "begin": "'",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.statamic"
+                }
+            },
+            "end": "'",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.statamic"
+                }
+            },
+            "name": "string.quoted.single.statamic",
+            "patterns": [
+                {
+                    "match": "\\\\[\\\\']",
+                    "name": "constant.character.escape.statamic"
+                },
+                {
+                    "begin": "(?<!@){(\\s?)",
+                    "end": "(\\s?)}",
+                    "patterns": [
+                        {
+                            "include": "#antlers-expression"
+                        }
+                    ]
+                }
+            ]
+        },
+        "antlers-strings": {
+            "patterns": [
+                {
+                    "include": "#string-double-quoted"
+                },
+                {
+                    "include": "#string-single-quoted"
+                }
+            ]
+        },
+        "antlers-expression": {
+            "patterns": [
+                {
+                    "match": ";",
+                    "name": "punctuation.terminator.expression.statamic"
+                },
+                {
+                    "include": "#antlers-strings"
+                },
+                {
+                    "include": "#antlers-numbers"
+                },
+                {
+                    "match": "=>",
+                    "name": "keyword.operator.key.statamic"
+                },
+                {
+                    "match": "->",
+                    "name": "keyword.operator.class.statamic"
+                },
+                {
+                    "include": "#antlers-attribute-bag"
+                },
+                {
+                    "include": "#statamic-explicit-tags"
+                },
+                {
+                    "include": "#statamic-core-tags"
+                },
+                {
+                    "match": "===|==|!==|!=|<>",
+                    "name": "keyword.operator.comparison.statamic"
+                },
+                {
+                    "match": "\\&=?",
+                    "name": "keyword.operator.string.statamic"
+                },
+                {
+                    "match": "=|\\+=|\\-=|\\*\\*?=|/=|%=|\\|=|\\^=|<<=|>>=",
+                    "name": "keyword.operator.assignment.statamic"
+                },
+                {
+                    "match": "(?<!-)\\b(?i)(!|\\?\\?|\\?=|\\?|&&|&|\\|\\|)|\\b(and|or|xor)\\b",
+                    "name": "keyword.operator.logical.statamic"
+                },
+                {
+                    "match": "(?i)\\b(bwa|bwo|bxor|bnot|bsl|bsr)\\b",
+                    "name": "keyword.operator.bitwise.statamic"
+                },
+                {
+                    "match": "<=>|<=|>=|<|>",
+                    "name": "keyword.operator.comparison.statamic"
+                },
+                {
+                    "match": "\\-|\\+|\\*\\*?|/|%",
+                    "name": "keyword.operator.arithmetic.statamic"
+                },
+                {
+                    "begin": "(arr|list|switch)\\s*(\\()",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "support.function.construct.statamic"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.array.begin.bracket.round.statamic"
+                        }
+                    },
+                    "end": "\\)|(?=\\?>)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.array.end.bracket.round.statamic"
+                        }
+                    },
+                    "name": "meta.array.statamic",
+                    "patterns": [
+                        {
+                            "include": "#antlers-expression"
+                        }
+                    ]
+                },
+                {
+                    "begin": "(?<!@){(\\s?)",
+                    "end": "(\\s?)}",
+                    "patterns": [
+                        {
+                            "include": "#antlers-expression"
+                        }
+                    ]
+                },
+                {
+                    "include": "#antlers-tag-parameter-variable"
+                },
+                {
+                    "include": "#antlers-language-operators"
+                },
+                {
+                    "include": "#antlers-variable"
+                },
+                {
+                    "include": "#antlers-modifier-pipe"
+                },
+                {
+                    "include": "#antlers-variable-modifier-name"
+                },
+                {
+                    "include": "#antlers-variable-modifiers"
+                },
+                {
+                    "include": "#antlers-constants"
+                }
+            ]
+        },
+        "antlers-tag-parameter-variable": {
+            "match": "(:?([\\S:]+?)(=)('|\")([^\\4]*?)(\\4))",
+            "captures": {
+                "1": {
+                    "patterns": [
+                        {
+                            "match": "\\\\([\\S:]+?)(=)('|\")([({].*?[}])('|\")",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.html"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.html"
+                                },
+                                "3": {
+                                    "name": "punctuation.definition.string.begin.html"
+                                },
+                                "4": {
+                                    "patterns": [
+                                        {
+                                            "include": "source.js"
+                                        }
+                                    ]
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.html"
+                                }
+                            }
+                        },
+                        {
+                            "match": "\\\\([\\S:]+?)(=)('|\")(.*?)(\\3)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name.html"
+                                },
+                                "2": {
+                                    "name": "punctuation.separator.key-value.html"
+                                },
+                                "3": {
+                                    "name": "punctuation.definition.string.begin.html"
+                                },
+                                "4": {
+                                    "name": "string.quoted.double.html"
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.html"
+                                }
+                            }
+                        },
+                        {
+                            "match": ":([\\S:]+?)(=)('|\")(.*?)(\\3)",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name"
+                                },
+                                "2": {
+                                    "name": "keyword.operator.assignment.statamic"
+                                },
+                                "3": {
+                                    "name": "punctuation.definition.string.begin.statamic"
+                                },
+                                "4": {
+                                    "patterns": [
+                                        {
+                                            "include": "#antlers-expression"
+                                        }
+                                    ]
+                                },
+                                "5": {
+                                    "name": "punctuation.definition.string.end.statamic"
+                                }
+                            }
+                        },
+                        {
+                            "match": "([\\S]+?)(=)(('|\")(.*?)(\\4))",
+                            "captures": {
+                                "1": {
+                                    "name": "entity.other.attribute-name"
+                                },
+                                "2": {
+                                    "name": "keyword.operator.assignment.statamic"
+                                },
+                                "3": {
+                                    "patterns": [
+                                        {
+                                            "include": "#string-single-quoted"
+                                        },
+                                        {
+                                            "include": "#string-double-quoted"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "antlers-constants": {
+            "match": "(\\G|\\s|\\b)(true|TRUE|false|FALSE|yes|YES|no|NO|null|as)\\s",
+            "captures": {
+                "2": {
+                    "name": "constant.language.statamic"
+                }
+            }
+        },
+        "antlers-variable-modifier-name": {
+            "match": "(\\s)?(\\|)(\\s)?(\\w+((^:([a-zA-Z0-9-_/-@]+)){1,2})?|((-|\\+|\\*|/|\\^|\\%):(\\d*)?\\.?(\\d+)))+",
+            "captures": {
+                "2": {
+                    "name": "keyword.operator.statamic"
+                },
+                "4": {
+                    "name": "support.function.statamic"
+                }
+            }
+        },
+        "antlers-variable-modifiers": {
+            "match": "(\\s)?(\\|)(\\s)?(\\w+((:([a-zA-Z0-9-_/-@]+)){1,2})?|((-|\\+|\\*|/|\\^|\\%):(\\d*)?\\.?(\\d+)))+",
+            "captures": {
+                "2": {
+                    "name": "keyword.operator.statamic"
+                },
+                "4": {
+                    "name": "support.function.statamic",
+                    "patterns": [
+                        {
+                            "include": "#antlers-expression"
+                        }
+                    ]
+                }
+            }
+        },
+        "statamic-core-tags": {
+            "match": "\\G(/?\\w+)+",
+            "captures": {
+                "1": {
+                    "name": "variable.statamic",
+                    "patterns": [
+                        {
+                            "include": "#core-tag-names"
+                        }
+                    ]
+                }
+            }
+        },
+        "statamic-explicit-tags": {
+            "match": "\\G(/?%\\w+)+",
+            "captures": {
+                "1": {
+                    "name": "entity.name.tag.statamic"
+                }
+            }
+        },
+        "statamic-core-closing-tags": {
+            "match": "\\/(\\w+)+",
+            "captures": {
+                "1": {
+                    "name": "variable.statamic",
+                    "patterns": [
+                        {
+                            "include": "#core-tag-names"
+                        }
+                    ]
+                }
+            }
+        },
+        "antlers-language-operators": {
+            "match": "(\\w+)[\\s]",
+            "captures": {
+                "1": {
+                    "name": "variable.statamic",
+                    "patterns": [
+                        {
+                            "include": "#antlers-numbers"
+                        },
+                        {
+                            "include": "#language-operators"
+                        }
+                    ]
+                }
+            }
+        },
+        "antlers-variable": {
+            "match": "(/?\\w+)(:)?(\\w+)?",
+            "captures": {
+                "1": {
+                    "name": "variable.statamic",
+                    "patterns": []
+                },
+                "2": {
+                    "name": "keyword.operator.statamic"
+                },
+                "3": {
+                    "name": "variable.statamic",
+                    "patterns": [
+                        {
+                            "include": "$self"
+                        }
+                    ]
+                }
+            }
+        },
+        "antlers-numbers": {
+            "match": "0|[1-9](?:_?[0-9]+)*",
+            "name": "constant.numeric.statamic"
+        },
+        "antlers-modifier-pipe": {
+            "match": "(\\|)",
+            "name": "keyword.operator.other.statamic"
+        },
+        "core-tag-names": {
+            "patterns": [
+                {
+                    "match": "(?i)\\b(taxonomy|cookie|user_groups|user_roles|get_site|collection|asset|nocache|vite|mount_url|form|assets|cache|can|dd|ddd|dump|get_content|get_error|get_errors|get_files|glide|in|increment|installed|is|iterate|foreach|link|locales|markdown|member|mix|nav|not_found|404|obfuscate|parent|partial|path|query|range|loop|redirect|relate|rotate|route|scope|section|session|set|structure|svg|theme|trans|trans_choice|user|users|widont|yields|yield|slot|once|noparse|view|stack|push)\\b",
+                    "name": "entity.name.tag.statamic"
+                }
+            ]
+        },
+        "language-operators": {
+            "patterns": [
+                {
+                    "match": "(?i)\\b(pluck|take|skip|arr|orderby|groupby|merge|where|switch|bwa|bwo|bxor|bnot|bsl|bsr|if|elseif|else|void)(\\b)",
+                    "name": "support.function.array.statamic"
+                }
+            ]
+        },
+        "antlers-directives": {
+            "patterns": [
+                {
+                    "begin": "(?<!@)(@(props|aware|cascade))\\b(?=\\s*\\()",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.directive.statamic"
+                        }
+                    },
+                    "end": "(?<=\\))",
+                    "name": "meta.directive.statamic",
+                    "patterns": [
+                        {
+                            "include": "#antlers-parentheses"
+                        }
+                    ]
+                },
+                {
+                    "match": "(?<!@)@cascade\\b(?!\\s*\\()",
+                    "name": "keyword.control.directive.statamic"
+                }
+            ]
+        },
+        "antlers-parentheses": {
+            "begin": "\\(",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.parameters.begin.statamic"
+                }
+            },
+            "end": "\\)",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.parameters.end.statamic"
+                }
+            },
+            "name": "meta.group.statamic",
+            "patterns": [
+                {
+                    "include": "#antlers-parentheses"
+                },
+                {
+                    "include": "#antlers-expression"
+                }
+            ]
+        },
+        "antlers-attribute-bag": {
+            "patterns": [
+                {
+                    "match": "\\battributes\\b",
+                    "name": "variable.language.statamic"
+                },
+                {
+                    "match": "\\b([A-Za-z_]\\w*)(\\.)(attributes)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "variable.statamic"
+                        },
+                        "2": {
+                            "name": "punctuation.accessor.statamic"
+                        },
+                        "3": {
+                            "name": "variable.language.statamic"
+                        }
+                    }
+                },
+                {
+                    "match": "(\\.)([A-Za-z_]\\w*)(?=\\s*\\()",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.accessor.statamic"
+                        },
+                        "2": {
+                            "name": "support.function.statamic"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Documents how to use Blade components within Antlers and how to write Blade components using Antlers (what a sentence 🤣)
-----

## Overview

Components are reusable, self-contained chunks of interface, such as callouts, cards, buttons, layouts, or whatever else you keep copying and pasting around your site. Antlers can render [Laravel Blade components](https://laravel.com/docs/13.x/blade#components), and anonymous components can be written with Antlers itself.

That gives you two closely related flavors of angle-bracket syntax:

| Syntax | What it renders |
| --- | --- |
| `<x-callout />` | A Laravel component class or anonymous component view. The view may use Blade or Antlers. |
| `<s:collection:blog>...</s:collection:blog>` | A Statamic [Tag](/tags) using component-style syntax. |
| `{{ collection:blog }}...{{ /collection:blog }}` | The same Statamic Tag using classic Antlers syntax. |

:::tip
[Partials](/frontend/antlers#partials) inherit the current Antlers scope and are perfect for straightforward includes. Components have their own scope and explicitly receive data through props, the Cascade, and slots.
:::

## Creating a component

Anonymous components live in `resources/views/components`. Give the view an `.antlers.html` extension to build it with Antlers:

```antlers
{{# resources/views/components/callout.antlers.html #}}
@props([
    'type' => 'info',
    'title' => 'Heads up!' | upper,
])

<aside {{ attributes.merge([
    'class' => 'callout callout--' + type,
]) }}>
    <h2>{{ title }}</h2>

    {{ if slot | has_actual_content }}
        <div>{{ slot }}</div>
    {{ /if }}
</aside>
```

Render it from any Antlers template with an `x-` tag. Paired components receive everything between their tags as the default `slot`:

```antlers
<x-callout class="mt-8">
    Save your work before continuing.
</x-callout>
```

Components without slot content may self-close:

```antlers
<x-callout type="warning" title="Back up first" />
```

Components in subdirectories use dot notation. For example, `resources/views/components/menu/item.antlers.html` becomes `<x-menu.item />`.

:::tip
**[Blade components](https://laravel.com/docs/blade#components) work, too!** Use them from Antlers without rewriting anything. Blade and Antlers components may even nest inside each other like one big, happy template-language family.
:::

## Props

The `@props` directive defines the data your component expects. Values with named keys provide defaults, and those defaults are Antlers expressions, not PHP. That means variables, operators, and modifiers like `upper` are all fair game, if that's your style.

```antlers
@props([
    'type' => 'info',
    'title' => 'Heads up!' | upper,
])
```

Literal attributes pass strings. Prefix an attribute with `:` to resolve its value from the Antlers scope, or use `:$variable` when the prop and variable share a name:

```antlers
{{ page_title = 'Back up first' }}
{{ type = 'warning' }}

<x-callout :title="page_title" :$type />
```

These are Antlers' [usual parameter rules](/frontend/antlers#tag-parameters), even when the component itself is written in Blade.

## Attributes

Attributes not declared as props are collected in the `attributes` bag. Render the bag directly, or call its Laravel methods with Antlers' dot syntax:

```antlers
<aside {{ attributes.merge([
    'class' => 'callout callout--' + type,
]) }}>
    ...
</aside>
```

The `merge` method adds the component's default attributes while preserving those passed by the caller. Class names are combined, so our earlier `class="mt-8"` joins the callout classes instead of booting them out of the club.

## Slots

The `slot` variable contains the component's unnamed content. Use the `has_actual_content` modifier when whitespace and HTML comments alone should count as empty:

```antlers
{{ if slot | has_actual_content }}
    <div>{{ slot }}</div>
{{ /if }}
```

The closely related `is_string` modifier is available when you need to distinguish an ordinary string from a slot object or another value:

```antlers
{{ if value | is_string }}
    {{ value }}
{{ /if }}
```

### Named slots

Use `<x-slot:name>` to send content to a named slot:

```antlers
<x-panel>
    <x-slot:heading class="text-xl">
        Fresh from the blog
    </x-slot:heading>

    The latest dispatches from our crew.
</x-panel>
```

The component receives the slot as a variable. Any attributes on the slot are available through its own `attributes` bag:

```antlers
{{# resources/views/components/panel.antlers.html #}}
<section>
    <header {{ heading.attributes }}>{{ heading }}</header>
    <div>{{ slot }}</div>
</section>
```

## Scope

A component does not inherit the Antlers variables or Cascade data around it. Variables created inside the component do not leak out, either. Pass values as props when they are part of the component's public API.

Slot content is the intentional exception. It is evaluated in the caller's scope, so variables available where you invoke the component remain available inside its default and named slots.

### Cascade data

Use `@cascade` when a component needs data from Statamic's [Cascade](/data-inheritance). Pass a list to import only the values you need. Values listed without defaults are required; a named key may provide a fallback:

```antlers
@cascade([
    'title',
    'eyebrow' => 'Latest',
])

<h2>{{ title }}</h2>
<p>{{ eyebrow }}</p>
```

Omit the arguments to import the entire Cascade:

```antlers
@cascade
```

Pulling in everything is convenient, but selecting values keeps the component's dependencies much easier to spot six months from now.

### Sharing parent props

The `@aware` directive lets a nested component consume props explicitly passed to an ancestor component. Here, the menu item picks up the menu's `tone`:

```antlers
{{# resources/views/components/menu.antlers.html #}}
@props([
    'tone' => 'light'
])

<nav class="menu menu--{{ tone }}">
    {{ slot }}
</nav>
```

```antlers
{{# resources/views/components/menu/item.antlers.html #}}
@aware([
    'tone' => 'light'
])

<a class="menu__item menu__item--{{ tone }}">{{ slot }}</a>
```

```antlers
<x-menu tone="dark">
    <x-menu.item>Docs</x-menu.item>
</x-menu>
```

Like `@props`, the values passed to `@aware` are Antlers expressions. Providing a fallback keeps the nested component useful when it appears outside its usual parent.

### Escaping directives

If you need any of these directives to appear as literal text, add another `@`:

```antlers
@@props(['example'])
@@aware(['example'])
@@cascade
```

This renders `@props(['example'])`, `@aware(['example'])`, and `@cascade` without evaluating them.

## Component-style Statamic Tags

Statamic Tags may also use HTML-like syntax in Antlers. Prefix the Tag with either `s:` or `statamic:` and otherwise use it as normal:

```antlers
<s:collection:pages limit="3">
    <a href="{{ url }}">{{ title }}</a>
</s:collection:pages>
```

This is equivalent to classic Antlers syntax:

```antlers
{{ collection:pages limit="3" }}
    <a href="{{ url }}">{{ title }}</a>
{{ /collection:pages }}
```

Parameters still follow Antlers rules, including dynamic values and shorthand:

```antlers
<s:collection :from="collection_handle" :$limit>
    <a href="{{ url }}">{{ title }}</a>
</s:collection>
```

You may use `s-` and `statamic-` prefixes instead if dashes feel more HTML-ish, and Tags without enclosed content may self-close. This syntax still invokes a Statamic Tag; it does not look for a component view in `resources/views/components`.