### PR TITLE
Fix env preprocessor

### DIFF
--- a/app/Markdown/StripEnvTrailingNewlines.php
+++ b/app/Markdown/StripEnvTrailingNewlines.php
@@ -8,6 +8,11 @@ use Torchlight\Engine\Preprocessors\PreprocessorArgs;
 
 class StripEnvTrailingNewlines implements Preprocessor
 {
+    public function supports(?string $grammarName): bool
+    {
+        return $grammarName === 'env';
+    }
+
     /**
      * Torchlight's env grammar uses `([^#]*)` for unquoted values, which
      * swallows the newline Phiki appends to every line. That leaves


### PR DESCRIPTION
Adds the required `supports` method to the `StripEnvTrailingNewlines` preprocessor.