### PR TITLE
Document v6.32.0

### DIFF
--- a/content/collections/fieldtypes/assets.md
+++ b/content/collections/fieldtypes/assets.md
@@ -178,7 +178,7 @@ Inside an asset variable's tag pair you'll have access to the following variable
 | `is_image` | `true` when file is one of `jpg`, `jpeg`, `png`, `gif`, or `webp`. |
 | `is_svg` | `true` when file is an `svg`. |
 | `is_pdf` | `true` when file is a `pdf`. |
-| `is_video` | `true` when file is one of `h264`, `mp4`, `m4v`, `ogv`, or `webm`. |
+| `is_video` | `true` when file is one of `h264`, `mp4`, `m4v`, `ogv`, `webm`, `mov`, `mpeg`, `mpg`, or `mkv`. |
 | `last_modified` | Formatted date string of the last modified time |
 | `last_modified_instance` | [Carbon][carbon] instance of the last modified time |
 | `last_modified_timestamp` | Unix timestamp of the last modified time |


### PR DESCRIPTION
This pull request documents the new features and improvements from [v6.32.0](https://github.com/statamic/cms/releases/tag/v6.32.0).

- Updated the `is_video` extension list on the Assets fieldtype to include `mov`, `mpeg`, `mpg`, and `mkv` — statamic/cms#15378

Note: `mov` was already missing from this list prior to this release; this also fixes that pre-existing gap while updating for the new extensions.