### PR TITLE
Avoid a Stache lookup on every request in the Markdown middleware

### DIFF
--- a/app/Http/Middleware/ServeMarkdown.php
+++ b/app/Http/Middleware/ServeMarkdown.php
@@ -32,29 +32,23 @@ class ServeMarkdown
             return $response;
         }
 
-        $uri = '/'.trim($request->path(), '/');
-
-        if ($uri === '/') {
-            $uri = '';
-        }
-
-        $entry = Data::findByUri($uri === '' ? '/' : $uri);
-
-        if (! $entry) {
+        if (! $this->isDocsPageRoute($request)) {
             return $this->handlePotentialDocsRedirect($request, $next($request));
         }
 
-        $prefersMarkdown = $this->prefersMarkdown($request);
+        $uri = '/'.trim($request->path(), '/');
 
-        $response = $prefersMarkdown
-            ? ($this->markdown)($uri)
-            : $next($request);
+        if ($this->prefersMarkdown($request)) {
+            $response = ($this->markdown)($uri);
+        } else {
+            $response = $next($request);
 
-        if (! $prefersMarkdown) {
-            $response->headers->set('Link', implode(', ', [
-                sprintf('<%s>; rel="alternate"; type="text/markdown"', MarkdownUrl::for($entry->url())),
-                sprintf('<%s>; rel="describedby"; type="text/plain"', url('/llms.txt')),
-            ]));
+            if ($response->isSuccessful()) {
+                $response->headers->set('Link', implode(', ', [
+                    sprintf('<%s>; rel="alternate"; type="text/markdown"', MarkdownUrl::for($uri)),
+                    sprintf('<%s>; rel="describedby"; type="text/plain"', url('/llms.txt')),
+                ]));
+            }
         }
 
         $this->addAcceptToVary($response);
@@ -64,6 +58,17 @@ class ServeMarkdown
         }
 
         return $response;
+    }
+
+    /**
+     * Statamic's catch-all front-end route. This middleware runs outside the static caching
+     * middleware, which lives on the front-end controller, so resolving the entry here to
+     * decide whether we're on a docs page would hit the Stache on every request, including
+     * ones that are about to be answered by a cached page.
+     */
+    private function isDocsPageRoute(Request $request): bool
+    {
+        return $request->route()?->getName() === 'statamic.site';
     }
 
     /**

--- a/tests/Feature/ServeMarkdownTest.php
+++ b/tests/Feature/ServeMarkdownTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Http\Middleware\ServeMarkdown;
 use Illuminate\Http\Request;
+use Statamic\Facades\Data;
 use Tests\TestCase;
 
 class ServeMarkdownTest extends TestCase
@@ -57,6 +58,8 @@ class ServeMarkdownTest extends TestCase
             'HTTP_ACCEPT' => 'text/html',
         ]);
 
+        $request->setRouteResolver(fn () => app('router')->getRoutes()->getByName('statamic.site'));
+
         $response = app(ServeMarkdown::class)->handle($request, fn () => response('cached', headers: [
             'Link' => '<https://example.com/stale>; rel="alternate"',
             'Vary' => 'Accept',
@@ -68,6 +71,48 @@ class ServeMarkdownTest extends TestCase
         $this->assertSame(1, substr_count($link, 'rel="alternate"'));
         $this->assertSame(1, substr_count($link, 'rel="describedby"'));
         $this->assertSame(['Accept'], $response->getVary());
+    }
+
+    public function test_cached_page_requests_do_not_touch_the_stache(): void
+    {
+        Data::spy();
+
+        $request = Request::create('/control-panel/users', server: [
+            'HTTP_ACCEPT' => 'text/html',
+        ]);
+
+        $request->setRouteResolver(fn () => app('router')->getRoutes()->getByName('statamic.site'));
+
+        app(ServeMarkdown::class)->handle($request, fn () => response('cached'));
+
+        Data::shouldNotHaveReceived('findByUri');
+    }
+
+    public function test_home_page_alternate_link_points_at_index_md(): void
+    {
+        $response = $this->get('/', ['Accept' => 'text/html']);
+
+        $response->assertOk();
+        $this->assertStringContainsString(
+            sprintf('<%s>; rel="alternate"; type="text/markdown"', url('/index.md')),
+            $response->headers->get('Link')
+        );
+    }
+
+    public function test_pages_outside_the_docs_route_have_no_alternate_link(): void
+    {
+        $response = $this->get('/search-results', ['Accept' => 'text/html']);
+
+        $response->assertOk();
+        $response->assertHeaderMissing('Link');
+    }
+
+    public function test_unknown_urls_have_no_alternate_link(): void
+    {
+        $response = $this->get('/nope-not-a-page', ['Accept' => 'text/html']);
+
+        $response->assertNotFound();
+        $response->assertHeaderMissing('Link');
     }
 
     public function test_legacy_url_with_markdown_accept_redirects_to_markdown_twin(): void


### PR DESCRIPTION
`ServeMarkdown` is prepended to the `web` middleware group, but Statamic's static caching middleware is applied by `FrontendController` — so this middleware runs *outside* it. Resolving the entry with `Data::findByUri()` to decide whether the request is for a docs page meant a Stache query plus entry hydration on every single request, including ones about to be answered by a statically cached page.

Two cheaper substitutes:

- **Is this a docs page?** The route is already resolved by the time group middleware runs, so checking for Statamic's catch-all route name (`statamic.site`) is free.
- **What's the alternate URL?** Derived from the request path instead of `$entry->url()`. Same output for docs entries.

Markdown-preferring requests still resolve the entry, but inside `DocsMarkdownController` where that was already happening.

The `Link` header is now only set on successful responses. Behaviour is otherwise unchanged — I diffed old vs new across 10 URLs (missing page, docs entry, home, legacy redirect, `search-results`, `sitemap.xml`, `llms.txt`; html and markdown `Accept` each) and status/Location/Link match on every row. The one difference: 404s under the catch-all now carry `Vary: Accept`, which is arguably more correct and doesn't affect caching (`share_errors` is off).

Adds tests covering the cached-request path (asserts `Data::findByUri` is never called), the home page's `/index.md` alternate, non-catch-all routes, and unknown URLs. The two tests that invoke the middleware directly now call `setRouteResolver()`, because a hand-built `Request` has no route attached — the router normally does that during dispatch, before the middleware runs.