### PR TITLE
Cache Markdown output in a dedicated store

### DIFF
--- a/app/Http/Controllers/DocsMarkdownController.php
+++ b/app/Http/Controllers/DocsMarkdownController.php
@@ -22,7 +22,7 @@ class DocsMarkdownController extends Controller
             return $this->redirectLegacyUri($uri);
         }
 
-        $markdown = Cache::rememberForever("markdown.$uri", function () use ($entry) {
+        $markdown = Cache::store('markdown')->rememberForever("markdown.$uri", function () use ($entry) {
             return collect([
                 '# '.$entry->value('title'),
                 $entry->value('intro'),

--- a/app/Http/Controllers/LlmsTxtController.php
+++ b/app/Http/Controllers/LlmsTxtController.php
@@ -28,7 +28,7 @@ class LlmsTxtController extends Controller
 
     public function __invoke()
     {
-        $lines = Cache::rememberForever('llms.txt', fn () => $this->build());
+        $lines = Cache::store('markdown')->rememberForever('llms.txt', fn () => $this->build());
 
         return response(implode("\n", $lines), 200, [
             'Content-Type' => 'text/plain; charset=UTF-8',

--- a/config/cache.php
+++ b/config/cache.php
@@ -104,6 +104,17 @@ return [
             'path' => storage_path('statamic/static-urls-cache'),
         ],
 
+        /*
+        | The Markdown twins of the docs pages, and llms.txt. These are derived entirely from
+        | git-tracked content, so they're kept in their own store that the deploy script can
+        | clear (`php artisan cache:clear markdown`) without touching the app cache.
+        */
+        'markdown' => [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/markdown'),
+            'lock_path' => storage_path('framework/cache/markdown'),
+        ],
+
     ],
 
     /*

--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,3 +1,4 @@
 *
 !data/
+!markdown/
 !.gitignore

--- a/storage/framework/cache/markdown/.gitignore
+++ b/storage/framework/cache/markdown/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The `.md` twins and `llms.txt` are cached with `rememberForever` in the default app cache. Nothing ever invalidates them — no listeners, no `forget` — and the app cache is intentionally left alone by the deploy script, so a content change could go on serving stale Markdown indefinitely.

They now live in their own `markdown` store, which the deploy script can clear alongside the stache and static cache:

```
php artisan cache:clear markdown
```